### PR TITLE
WMDP-84 Create Terraform resources for eligibility screener

### DIFF
--- a/infra/template/ecs.tf
+++ b/infra/template/ecs.tf
@@ -1,0 +1,14 @@
+# configuration for ECS Fargate should go here
+# resource "aws_ecs_task_definition" "eligibility_screener_task" {
+  
+# }
+
+# resource "aws_ecs_service" "eligibility_screener_service" {
+#   name = "eligibility_screener_service"
+#   task_definition = aws_ecs_task_definition.eligibility_screener_task
+#   cluster = "" # not sure this is needed
+#   launch_type = "FARGATE"
+#   iam_role = "" # role needs to be created so that the task doesn't need to be manually triggered
+  
+# }
+

--- a/infra/template/main.tf
+++ b/infra/template/main.tf
@@ -1,0 +1,16 @@
+# this file should contain information about tf versions and required providers
+
+terraform {
+  required_version = "1.2.0"
+
+  required_providers {
+    aws  = {
+      source  = "hashicorp/aws"
+      version = "~> 4.16.0" 
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}

--- a/infra/template/s3.tf
+++ b/infra/template/s3.tf
@@ -26,6 +26,7 @@ resource "aws_s3_bucket_public_access_block" "wic_mt_host" {
 }
 
 # create iam policy for bucket
+# todo: update the policy document
 data "aws_iam_policy_document" "wic_mt_host_policy" {
   statement {
     sid = "AllowListBucket"

--- a/infra/template/s3.tf
+++ b/infra/template/s3.tf
@@ -1,0 +1,1 @@
+# anything relating to the creation or content of s3 buckets go here

--- a/infra/template/s3.tf
+++ b/infra/template/s3.tf
@@ -1,1 +1,44 @@
 # anything relating to the creation or content of s3 buckets go here
+
+# bucket for hosting
+resource "aws_s3_bucket" "wic_mt_host_bucket" {
+  bucket = "wic-mt-site-builds"
+}
+
+# encrypt data
+resource "aws_s3_bucket_server_side_encryption_configuration" "wic_mt" {
+  bucket = aws_s3_bucket.wic_mt_host_bucket.bucket
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+      }
+    }
+  }
+
+# block public access
+resource "aws_s3_bucket_public_access_block" "wic_mt_host" {
+  bucket = aws_s3_bucket.wic_mt_host_bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# create iam policy for bucket
+data "aws_iam_policy_document" "wic_mt_host_policy" {
+  statement {
+    sid = "AllowListBucket"
+    actions = [ 
+      "s3:ListAllMyBuckets",
+      "s3:GetBucketLocation" 
+      ]
+    resources = [ "arn:aws:s3:::${aws_s3_bucket.wic_mt_host_bucket}" ]
+  }
+}
+
+# add policy to bucket
+resource "aws_bucket_policy" "wic_mt_host_bucket"{
+  bucket = aws_s3_bucket.wic_mt_host_bucket.id
+  policy = data.aws_iam_policy_document.wic_mt_host_policy.json
+}


### PR DESCRIPTION
## Ticket
https://wicmtdp.atlassian.net/browse/WMDP-84

## Changes
* pinned Terraform version
* start setup for s3 bucket needed for hosting
* rough draft for Fargate resources
* begin standardizing infra file structure

## Context for reviewers
> This ticket will cover the initial set up for [Terraform](https://www.terraform.io/use-cases/infrastructure-as-code), which is our Infrastructure as Code provider. Initial setup will require installing a version of terraform and configuring providers such as [hashicorp/aws](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)(allows terraform to interact with AWS services)

**Subfolders explained** 
`template`: these are shared resource configurations that need to be developed across all environments. (e.g.  an s3 bucket that gets replicated with each environment)
 **current folders include**:
* `main.tf` &rarr; primary entrypoint for terraform. This holds information such as the version of terraform and what add-ons (such as the AWS provider) are needed
* `s3.tf` &rarr; configurations for s3 buckets
* `ecs.tf` &rarr; configuration for Fargate


`environments`: environment-specific resources and configurations. (e.g. environment variables and their values)
No sub-folders in this one yet. That will be addressed in [WMDP-97](https://wicmtdp.atlassian.net/browse/WMDP-97)

## Testing
TBA

