### PR TITLE
Remove boilerplate Apache 2.0 license appendix added by Github

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -174,28 +174,3 @@
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.


### PR DESCRIPTION
## Ticket

Related to https://wicmtdp.atlassian.net/browse/WMDP-83

## Changes
> What was added, updated, or removed in this PR.

- Modified `LICENSE.md` to remove boilerplate added by Github

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

@lorenyu [caught a bug](https://github.com/navapbc/template-application-nextjs/pull/13#discussion_r904367265) in the related PR in https://github.com/navapbc/template-application-nextjs/pull/13. Namely, that it appeared that there was some boilerplate language included in `LICENSE.md`. After reviewing https://www.apache.org/licenses/LICENSE-2.0.html#apply, I determined that we should remove that language. It's needed if you are applying the license to "specific files in your work".

## Testing
> Screenshots, GIF demos, code examples or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

N/A