### PR TITLE
Karina/wmdp 119 alternate benefits

### DIFF
--- a/app/public/locales/en/common.json
+++ b/app/public/locales/en/common.json
@@ -1,4 +1,11 @@
 {
+  "Alternate": {
+    "assistance": "We recommend visiting <0>https://dphhs.mt.gov/Assistance</0> to learn about other assistance in Montana.",
+    "button": "Return to start page",
+    "location": "If you are not currently living or working in Montana, visit <0>SignUpWIC.com</0> to find a clinic near you.",
+    "subHeader": "Given your responses, you are likely not eligible for WIC.",
+    "title": "Your eligibility"
+  },
   "Clinic": {
     "body": "You’ll need to visit a clinic in person to complete a certification appointment for WIC. Choose the clinic you would like to go to during business hours.",
     "button": "Select this clinic and continue",

--- a/app/src/components/ButtonLink.tsx
+++ b/app/src/components/ButtonLink.tsx
@@ -17,6 +17,7 @@ const ButtonLink = (props: Props): ReactElement => {
       <Button
         className={`usa-button usa-button--small`}
         disabled={disabled}
+        href={href}
         width={width}
       >
         {label}

--- a/app/src/pages/alternate.tsx
+++ b/app/src/pages/alternate.tsx
@@ -28,6 +28,7 @@ const Alternate: NextPage = () => {
       />
       <br />
       <br />
+      <br />
       <StyledButton href="/" label={t('Alternate.button')} width="180px" />
       <br />
     </>

--- a/app/src/pages/alternate.tsx
+++ b/app/src/pages/alternate.tsx
@@ -1,0 +1,49 @@
+import type { GetServerSideProps, NextPage } from 'next'
+import { Trans, useTranslation } from 'next-i18next'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import Link from 'next/link'
+import styled from 'styled-components'
+
+import ButtonLink from '@components/ButtonLink'
+
+const Alternate: NextPage = () => {
+  const { t } = useTranslation('common')
+
+  return (
+    <>
+      <Link href="/eligibility">Back</Link>
+      <h1>{t('Alternate.title')}</h1>
+      <h2>{t('Alternate.subHeader')}</h2>
+      <Trans
+        components={[<a key="0" href="https://dphhs.mt.gov/Assistance" />]}
+        i18nKey={'Alternate.assistance'}
+        t={t}
+      />
+      <br />
+      <br />
+      <Trans
+        components={[<a key="0" href="https://www.signupwic.com/" />]}
+        i18nKey={'Alternate.location'}
+        t={t}
+      />
+      <br />
+      <br />
+      <StyledButton href="/" label={t('Alternate.button')} width="180px" />
+      <br />
+    </>
+  )
+}
+
+const StyledButton = styled(ButtonLink)`
+  margin: 2rem 0;
+`
+
+export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale || 'en', ['common'])),
+    },
+  }
+}
+
+export default Alternate

--- a/app/src/pages/eligibility.tsx
+++ b/app/src/pages/eligibility.tsx
@@ -2,13 +2,15 @@ import type { GetServerSideProps, NextPage } from 'next'
 import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import Link from 'next/link'
-import { ChangeEvent, useState } from 'react'
+import { ChangeEvent, useEffect, useState } from 'react'
 
 import ButtonLink from '@components/ButtonLink'
 import InputChoiceGroup from '@components/InputChoiceGroup'
 
 const Eligibility: NextPage = () => {
   const { t } = useTranslation('common')
+  const incomeRoute = '/income'
+  const [continueLink, setContinueLink] = useState(incomeRoute)
   const [form, setForm] = useState({
     residential: '',
     pregnant: false,
@@ -22,6 +24,12 @@ const Eligibility: NextPage = () => {
     tanf: false,
     none2: false,
   })
+
+  useEffect(() => {
+    if (form.none) {
+      setContinueLink('/alternate')
+    } else setContinueLink(incomeRoute)
+  }, [form.none])
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { value, name }: { value: string; name: string } = e.target
@@ -104,16 +112,16 @@ const Eligibility: NextPage = () => {
             value: 'guardian',
           },
           {
-            checked: form.none,
-            handleChange,
-            label: t('Eligibility.none'),
-            value: 'none',
-          },
-          {
             checked: form.loss,
             handleChange,
             label: t('Eligibility.loss'),
             value: 'loss',
+          },
+          {
+            checked: form.none,
+            handleChange,
+            label: t('Eligibility.none'),
+            value: 'none',
           },
         ]}
       />
@@ -152,7 +160,7 @@ const Eligibility: NextPage = () => {
       <br />
       <br />
       <br />
-      <ButtonLink href="/income" label={t('continue')} width="105px" />
+      <ButtonLink href={continueLink} label={t('continue')} width="105px" />
       <br />
     </form>
   )

--- a/app/stories/pages/Alternate.stories.tsx
+++ b/app/stories/pages/Alternate.stories.tsx
@@ -1,0 +1,12 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+
+import AlternatePage from '@pages/alternate'
+
+export default {
+  title: 'Pages',
+  component: AlternatePage,
+} as ComponentMeta<typeof AlternatePage>
+
+const Template: ComponentStory<typeof AlternatePage> = () => <AlternatePage />
+
+export const Clinic = Template.bind({})

--- a/app/tests/pages/__snapshots__/alternate.test.tsx.snap
+++ b/app/tests/pages/__snapshots__/alternate.test.tsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Alternate should render the heading 1`] = `
+<h1>
+  Your eligibility
+</h1>
+`;

--- a/app/tests/pages/alternate.test.tsx
+++ b/app/tests/pages/alternate.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { axe } from 'jest-axe'
+
+import Alternate from '@pages/alternate'
+
+describe('Alternate', () => {
+  it('should render the heading', () => {
+    render(<Alternate />)
+
+    const heading = screen.getByText(/Your eligibility/i)
+
+    expect(heading).toBeInTheDocument()
+    expect(heading).toMatchSnapshot()
+  })
+
+  it('should pass accessibility scan', async () => {
+    const { container } = render(<Alternate />)
+    const results = await axe(container)
+
+    await waitFor(() => {
+      expect(results).toHaveNoViolations()
+    })
+  })
+})

--- a/app/tests/pages/eligibility.test.tsx
+++ b/app/tests/pages/eligibility.test.tsx
@@ -31,4 +31,28 @@ describe('Eligibility', () => {
       expect(yesRadio).toBeChecked()
     })
   })
+
+  describe('continue link', () => {
+    it('should link to income page by default', () => {
+      render(<Eligibility />)
+
+      const continueBtn = screen.getByText(/Continue/i)
+
+      expect(continueBtn.getAttribute('href')).toBe('/income')
+    })
+
+    it('should link to alternate page if none is selected for question 2', () => {
+      render(<Eligibility />)
+
+      const noneBtn = screen.getAllByLabelText(/None of the above/i)[0]
+
+      expect(noneBtn).not.toBeChecked()
+      fireEvent.click(noneBtn)
+      expect(noneBtn).toBeChecked()
+
+      const continueBtn = screen.getByText(/Continue/i)
+
+      expect(continueBtn.getAttribute('href')).toBe('/alternate')
+    })
+  })
 })


### PR DESCRIPTION
## Ticket

https://wicmtdp.atlassian.net/browse/WMDP-119

## Changes
> What was added, updated, or removed in this PR.
- adds alternate page 
- adds conditional routing to eligibility page 
   - if "None of the above" is selected for second question, "continue" button routes to alternate benefits page

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.
- run jest tests 
- assert that you are routed to alternate benefits page if you select none of the above for second question in eligibility page 
- assert that eligibility page routes to  income page by default 

## Testing
> Screenshots, GIF demos, code examples or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.


https://user-images.githubusercontent.com/14364118/184664620-ca145f6f-59c6-466b-a7c3-2fd32574c9d2.mov


