### PR TITLE
WMDP-204: Apply USWDS grid layout

### DIFF
--- a/app/src/components/Layout.tsx
+++ b/app/src/components/Layout.tsx
@@ -1,7 +1,6 @@
 import { Trans, useTranslation } from 'next-i18next'
 import Image from 'next/image'
 import { ReactElement } from 'react'
-import styled from 'styled-components'
 
 type Props = {
   children: ReactElement
@@ -12,61 +11,72 @@ const Layout = ({ children }: Props): ReactElement => {
 
   return (
     <div className="container">
-      <header className="usa-header usa-header--basic">
-        <div className="usa-nav-container">
-          <div className="usa-navbar">
-            <div className="usa-logo">
-              <em className="usa-logo__text">{t('Layout.header')}</em>
+      <header className="header usa-header usa-header--basic">
+        <div className="usa-navbar">
+          <div className="grid-row">
+            <div className="desktop:grid-col-8 desktop:grid-offset-2">
+              <div className="usa-logo margin-left-2">
+                <em className="usa-logo__text">{t('Layout.header')}</em>
+              </div>
             </div>
           </div>
         </div>
       </header>
-      <main className="main">{children}</main>
-      <footer className="footer">
-        <Logos>
-          <Image
-            src="/img/wic-logo.svg"
-            alt="WIC logo"
-            width={64.52}
-            height={32}
-          />
-          <Image
-            src="/img/montana-logo.svg"
-            alt="Monthana DPHHS logo"
-            width={46.22}
-            height={32}
-          />
-        </Logos>
-        <br />
-        <div>
-          <Trans
-            components={[
-              <a key="0" href="https://dphhs.mt.gov/ecfsd/wic/index" />,
-              <a key="1" href="https://www.signupwic.com/" />,
-            ]}
-            i18nKey={'Layout.footer1'}
-            t={t}
-          />
-          <br />
-          <br />
-          <Trans
-            components={[
-              <a
-                key="0"
-                href="https://www.fns.usda.gov/civil-rights/usda-nondiscrimination-statement-other-fns-programs"
-              />,
-            ]}
-            i18nKey={'Layout.footer2'}
-            t={t}
-          />
+      <main className="main">
+        <div className="grid-row">
+          <div className="desktop:grid-col-8 desktop:grid-offset-2  padding-2">
+            {children}
+          </div>
+        </div>
+      </main>
+      <footer className="footer usa-footer usa-footer--slim">
+        <div className="usa-footer__primary-section">
+          <div className="grid-row">
+            <div className="desktop:grid-col-8 desktop:grid-offset-2 padding-2">
+              <div className="logos">
+                <Image
+                  src="/img/wic-logo.svg"
+                  alt="WIC logo"
+                  width={64.52}
+                  height={32}
+                />
+                <Image
+                  src="/img/montana-logo.svg"
+                  alt="Monthana DPHHS logo"
+                  width={46.22}
+                  height={32}
+                />
+              </div>
+              <div className="font-body-3xs">
+                <p>
+                  <Trans
+                    components={[
+                      <a key="0" href="https://dphhs.mt.gov/ecfsd/wic/index" />,
+                      <a key="1" href="https://www.signupwic.com/" />,
+                    ]}
+                    i18nKey={'Layout.footer1'}
+                    t={t}
+                  />
+                </p>
+                <p>
+                  <Trans
+                    components={[
+                      <a
+                        key="0"
+                        href="https://www.fns.usda.gov/civil-rights/usda-nondiscrimination-statement-other-fns-programs"
+                      />,
+                    ]}
+                    i18nKey={'Layout.footer2'}
+                    t={t}
+                  />
+                </p>
+              </div>
+            </div>
+          </div>
         </div>
       </footer>
     </div>
   )
 }
 
-const Logos = styled.div`
-  display: grid;
-  grid-template-columns: repeat(2, 80px);
-`
 export default Layout

--- a/app/src/components/Layout.tsx
+++ b/app/src/components/Layout.tsx
@@ -11,7 +11,7 @@ const Layout = ({ children }: Props): ReactElement => {
 
   return (
     <div className="container">
-      <header className="header usa-header usa-header--basic">
+      <header className="header usa-header usa-header--basic" role="banner">
         <div className="usa-navbar">
           <div className="grid-row">
             <div className="desktop:grid-col-8 desktop:grid-offset-2">

--- a/app/styles/_uswds-theme-custom-styles.scss
+++ b/app/styles/_uswds-theme-custom-styles.scss
@@ -22,40 +22,28 @@ i.e.
 
 @use 'uswds-core' as *;
 
+// Sticky footer
 .container {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
 }
 
-.header {
-  padding: 2rem;
-  position: sticky;
-  top: 0;
-}
-
-.footer {
-  background-color: rgb(250, 250, 250);
-  border-top: 1px solid black;
-  bottom: 0;
-  font-size: small;
-  padding: 1rem;
-  width: 100%;
-}
-
 .main {
   flex: 1;
-  justify-content: center;
-  overflow-y: scroll;
-  padding: 2rem;
 }
 
-.title a {
-  text-decoration: none;
+// Footer
+.footer .logos .logo-image {
+  margin-right: 1rem;
 }
 
-.title a:hover,
-.title a:focus,
-.title a:active {
-  text-decoration: underline;
-}
+// .title a {
+//   text-decoration: none;
+// }
+
+// .title a:hover,
+// .title a:focus,
+// .title a:active {
+//   text-decoration: underline;
+// }

--- a/app/styles/_uswds-theme-custom-styles.scss
+++ b/app/styles/_uswds-theme-custom-styles.scss
@@ -44,7 +44,6 @@ i.e.
 }
 
 .main {
-  align-items: center;
   flex: 1;
   justify-content: center;
   overflow-y: scroll;

--- a/app/styles/_uswds-theme-custom-styles.scss
+++ b/app/styles/_uswds-theme-custom-styles.scss
@@ -42,13 +42,3 @@ i.e.
 .footer .logos > span {
   margin-right: 1.5rem !important;
 }
-
-// .title a {
-//   text-decoration: none;
-// }
-
-// .title a:hover,
-// .title a:focus,
-// .title a:active {
-//   text-decoration: underline;
-// }

--- a/app/styles/_uswds-theme-custom-styles.scss
+++ b/app/styles/_uswds-theme-custom-styles.scss
@@ -22,7 +22,8 @@ i.e.
 
 @use 'uswds-core' as *;
 
-// Sticky footer
+// Sticky footer:
+// USWDS surprisingly doesn't support this with any of their utilities or components.
 .container {
   min-height: 100vh;
   display: flex;
@@ -33,9 +34,13 @@ i.e.
   flex: 1;
 }
 
-// Footer
-.footer .logos .logo-image {
-  margin-right: 1rem;
+// Footer logo spacing:
+// Currently the next/image component wraps the <img> tag in a bunch of <spans>
+// and applies direct css onto all those elements. To overcome it, we need
+// to manually override the parent element span using the unfortunate !important
+// See https://github.com/vercel/next.js/discussions/18312
+.footer .logos > span {
+  margin-right: 1.5rem !important;
 }
 
 // .title a {

--- a/app/styles/_uswds-theme.scss
+++ b/app/styles/_uswds-theme.scss
@@ -14,5 +14,7 @@ in the form $setting: value,
   // Specify USWDS font and image paths.
   // Same paths are successfully used for both Next.js and Storybook.
   $theme-font-path: '/uswds/fonts',
-  $theme-image-path: '/uswds/img'
+  $theme-image-path: '/uswds/img',
+
+  $theme-header-logo-text-width: 100%
 );


### PR DESCRIPTION
## Ticket

- https://wicmtdp.atlassian.net/browse/WMDP-204

## Changes
> What was added, updated, or removed in this PR.

- Apply the [USWDS ayout Grid](https://designsystem.digital.gov/utilities/layout-grid/) for mobile and desktop breakpoints with different grid layouts
- Use [USWDS margin and padding utility](https://designsystem.digital.gov/utilities/margin-and-padding/) for elements that don't have preset component spacing
- Use [USWDS header component](https://designsystem.digital.gov/components/header/) override `$theme-header-logo-text-width` to allow it to break out of the layout grid container (we want 100%, not the default breakpoint max width)
- Add override styling to footer logos to deal with [next/image](https://nextjs.org/docs/api-reference/next/image) limitations
- Remove custom style overrides

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

We identified in a recent UAT that we were missing non-mobile styles and determined that we needed to apply the USWDS grid.

## Testing
> Screenshots, GIF demos, code examples or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

Here is the grid applied for mobile-first, which applies up until we hit the desktop breakpoint:
![Screen Shot 2022-09-16 at 8 52 45 AM](https://user-images.githubusercontent.com/67701/190680287-57027083-ab8c-4bd8-a638-481b98a03e67.png)

Here is the grid on the desktop breakpoint:
![Screen Shot 2022-09-16 at 8 53 33 AM](https://user-images.githubusercontent.com/67701/190680346-52dad103-265d-40fb-a930-f974439aa63f.png)

Here is that same desktop breakpoint that demonstrates that we are using 2 columns on the left, 8 columns in the middle, and 2 columns on the right:
![Screen Shot 2022-09-16 at 8 53 52 AM](https://user-images.githubusercontent.com/67701/190680478-0a1aece5-db56-470c-817f-1f43e5aafb4a.png)


