### PR TITLE
Handle redirect on /confirmation if no user data

### DIFF
--- a/app/src/pages/_app.tsx
+++ b/app/src/pages/_app.tsx
@@ -2,6 +2,7 @@ import { appWithTranslation } from 'next-i18next'
 import type { AppProps } from 'next/app'
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
+import { UrlObject } from 'url'
 
 import Layout from '@components/Layout'
 import PageError from '@components/PageError'
@@ -29,12 +30,15 @@ function MyApp({ Component, pageProps }: AppProps) {
   useEffect(() => {
     try {
       const outcome = hasRoutingIssues(router.pathname, session)
-      if (outcome.error) {
+      if (outcome.hasIssues) {
+        const redirectTo: UrlObject = {
+          pathname: outcome.redirect,
+        }
+        if (outcome.showError) {
+          redirectTo.query = { error: 'missing-data' }
+        }
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        router.push({
-          pathname: outcome.cause,
-          query: { error: 'missing-data' },
-        })
+        router.push(redirectTo)
       }
     } catch (e: unknown) {
       const error = e as Error

--- a/app/src/utils/dataValidation.ts
+++ b/app/src/utils/dataValidation.ts
@@ -86,37 +86,41 @@ function isDefined(
   return true
 }
 
-export function isValidSession(session: SessionData): boolean {
-  const checks = [
-    { dataType: initialSessionData, data: session },
-    { dataType: initialEligibilityData, data: session.eligibility },
-    { dataType: initialIncomeData, data: session.income },
-    { dataType: initialChooseClinicData, data: session.chooseClinic },
-    { dataType: initialContactData, data: session.contact },
-  ]
-
-  for (let i = 0, len = checks.length; i < len; i++) {
-    if (!isDefined(checks[i].dataType, checks[i].data)) {
-      return false
-    }
-  }
-
-  if (!isValidEligibility(session.eligibility)) {
+export function isValidSession(session: SessionData, check = 'any'): boolean {
+  if (!isDefined(initialSessionData, session)) {
     return false
   }
 
   if (
-    session.eligibility.adjunctive.includes('none') &&
-    !isValidIncome(session.income)
+    (check === 'eligibility' || check === 'any') &&
+    (!isDefined(initialEligibilityData, session.eligibility) ||
+      !isValidEligibility(session.eligibility))
   ) {
     return false
   }
 
-  if (!isValidChooseClinic(session.chooseClinic)) {
+  if (
+    (check === 'income' || check === 'any') &&
+    (!isDefined(initialIncomeData, session.income) ||
+      (session.eligibility.adjunctive.includes('none') &&
+        !isValidIncome(session.income)))
+  ) {
     return false
   }
 
-  if (!isValidContact(session.contact)) {
+  if (
+    (check === 'choose-clinic' || check === 'any') &&
+    (!isDefined(initialChooseClinicData, session.chooseClinic) ||
+      !isValidChooseClinic(session.chooseClinic))
+  ) {
+    return false
+  }
+
+  if (
+    (check === 'contact' || check === 'any') &&
+    (!isDefined(initialContactData, session.contact) ||
+      !isValidContact(session.contact))
+  ) {
     return false
   }
 

--- a/app/src/utils/routing.ts
+++ b/app/src/utils/routing.ts
@@ -2,10 +2,9 @@ import { UrlObject } from 'url'
 
 import { SessionData } from '@src/types'
 import {
-  isValidChooseClinic,
-  isValidContact,
   isValidEligibility,
   isValidIncome,
+  isValidSession,
 } from '@utils/dataValidation'
 
 interface RestrictedPages {
@@ -155,10 +154,10 @@ export function hasRoutingIssues(
   // These pages have restricted access based on user data.
   // All other pages have no routing issues.
   const restrictedPages: RestrictedPages = {
-    '/income': ['/eligibility'],
-    '/choose-clinic': ['/eligibility', '/income'],
-    '/contact': ['/eligibility', '/income', '/choose-clinic'],
-    '/review': ['/eligibility', '/income', '/choose-clinic', '/contact'],
+    '/income': ['eligibility'],
+    '/choose-clinic': ['eligibility', 'income'],
+    '/contact': ['eligibility', 'income', 'choose-clinic'],
+    '/review': ['eligibility', 'income', 'choose-clinic', 'contact'],
   }
   if (!Object.keys(restrictedPages).includes(pathname)) {
     return pass
@@ -171,45 +170,10 @@ export function hasRoutingIssues(
     else {
       for (let i = 0, len = restrictedPages[pathname].length; i < len; i++) {
         const check = restrictedPages[pathname][i]
-        // Check first for /eligibility requirements.
-        if (
-          check === '/eligibility' &&
-          !isValidEligibility(session.eligibility)
-        ) {
+        if (!isValidSession(session, check)) {
           return {
             error: true,
-            cause: 'eligibility',
-          }
-        }
-
-        // Then, check for /income requirements.
-        if (
-          check === '/income' &&
-          session.eligibility.adjunctive.includes('none') &&
-          !isValidIncome(session.income)
-        ) {
-          return {
-            error: true,
-            cause: 'income',
-          }
-        }
-
-        // Then, check for /choose-clinic requirements.
-        if (
-          check === '/choose-clinic' &&
-          !isValidChooseClinic(session.chooseClinic)
-        ) {
-          return {
-            error: true,
-            cause: 'choose-clinic',
-          }
-        }
-
-        // Then, check for /contact requirements.
-        if (check === '/contact' && !isValidContact(session.contact)) {
-          return {
-            error: true,
-            cause: 'contact',
+            cause: check,
           }
         }
       }

--- a/app/tests/utils/routing/hasRoutingIssues.test.ts
+++ b/app/tests/utils/routing/hasRoutingIssues.test.ts
@@ -18,8 +18,9 @@ interface RoutingTestCombo {
   validIncome?: string
   validChooseClinic?: string
   validContact?: string
-  error: boolean
-  cause: string
+  hasIssues: boolean
+  showError: boolean
+  redirect: string
 }
 
 /**
@@ -91,7 +92,8 @@ it('should have no issues on /', () => {
   const pathname = '/'
   singletonRouter.push(pathname)
   const outcome = hasRoutingIssues(pathname, mockSession)
-  expect(outcome.error).toBe(false)
+  expect(outcome.hasIssues).toBe(false)
+  expect(outcome.showError).toBe(false)
 })
 
 it('should have no issues on /how-it-works', () => {
@@ -99,7 +101,8 @@ it('should have no issues on /how-it-works', () => {
   const pathname = '/how-it-works'
   singletonRouter.push(pathname)
   const outcome = hasRoutingIssues(pathname, mockSession)
-  expect(outcome.error).toBe(false)
+  expect(outcome.hasIssues).toBe(false)
+  expect(outcome.showError).toBe(false)
 })
 
 it('should have no issues on /eligibility', () => {
@@ -107,15 +110,8 @@ it('should have no issues on /eligibility', () => {
   const pathname = '/eligibility'
   singletonRouter.push(pathname)
   const outcome = hasRoutingIssues(pathname, mockSession)
-  expect(outcome.error).toBe(false)
-})
-
-it('should have no issues on /confirmation', () => {
-  const mockSession = getEmptyMockSession()
-  const pathname = '/confirmation'
-  singletonRouter.push(pathname)
-  const outcome = hasRoutingIssues(pathname, mockSession)
-  expect(outcome.error).toBe(false)
+  expect(outcome.hasIssues).toBe(false)
+  expect(outcome.showError).toBe(false)
 })
 
 it('should have no issues on /other-benefits', () => {
@@ -123,7 +119,8 @@ it('should have no issues on /other-benefits', () => {
   const pathname = '/other-benefits'
   singletonRouter.push(pathname)
   const outcome = hasRoutingIssues(pathname, mockSession)
-  expect(outcome.error).toBe(false)
+  expect(outcome.hasIssues).toBe(false)
+  expect(outcome.showError).toBe(false)
 })
 
 it('should have no issues on unknown pages', () => {
@@ -131,7 +128,8 @@ it('should have no issues on unknown pages', () => {
   const pathname = '/unknown'
   singletonRouter.push(pathname)
   const outcome = hasRoutingIssues(pathname, mockSession)
-  expect(outcome.error).toBe(false)
+  expect(outcome.hasIssues).toBe(false)
+  expect(outcome.showError).toBe(false)
 })
 
 /**
@@ -152,24 +150,27 @@ it('should throw an error if a function is passed instead of a session on a rest
 const incomePageCombos: RoutingTestCombo[] = [
   {
     validEligibility: 'invalid',
-    error: true,
-    cause: 'eligibility',
+    hasIssues: true,
+    showError: true,
+    redirect: 'eligibility',
   },
   {
     validEligibility: 'valid',
-    error: false,
-    cause: '',
+    hasIssues: false,
+    showError: false,
+    redirect: '',
   },
 ]
 it.each(incomePageCombos)(
-  '/income should have issues ($error caused by $cause) with $validEligibility eligibility',
-  ({ validEligibility, error, cause }) => {
+  '/income should have issues ($hasIssues caused by $redirect) with $validEligibility eligibility',
+  ({ validEligibility, hasIssues, showError, redirect }) => {
     const mockSession = buildRoutingIssuesMockSession(validEligibility)
     const pathname = '/income'
     singletonRouter.push(pathname)
     const outcome = hasRoutingIssues(pathname, mockSession)
-    expect(outcome.error).toBe(error)
-    expect(outcome.cause).toBe(cause)
+    expect(outcome.hasIssues).toBe(hasIssues)
+    expect(outcome.showError).toBe(showError)
+    expect(outcome.redirect).toBe(redirect)
   }
 )
 
@@ -178,36 +179,41 @@ const invalidChooseClinicPageCombos: RoutingTestCombo[] = [
     validEligibility: 'valid',
     adjunctiveMatch: 'none',
     validIncome: 'invalid',
-    error: true,
-    cause: 'income',
+    hasIssues: true,
+    showError: true,
+    redirect: 'income',
   },
   {
     validEligibility: 'invalid',
     adjunctiveMatch: 'none',
     validIncome: 'invalid',
-    error: true,
-    cause: 'eligibility',
+    hasIssues: true,
+    showError: true,
+    redirect: 'eligibility',
   },
   {
     validEligibility: 'invalid',
     adjunctiveMatch: 'none',
     validIncome: 'valid',
-    error: true,
-    cause: 'eligibility',
+    hasIssues: true,
+    showError: true,
+    redirect: 'eligibility',
   },
   {
     validEligibility: 'invalid',
     adjunctiveMatch: 'tanf',
     validIncome: 'valid',
-    error: true,
-    cause: 'eligibility',
+    hasIssues: true,
+    showError: true,
+    redirect: 'eligibility',
   },
   {
     validEligibility: 'invalid',
     adjunctiveMatch: 'tanf',
     validIncome: 'invalid',
-    error: true,
-    cause: 'eligibility',
+    hasIssues: true,
+    showError: true,
+    redirect: 'eligibility',
   },
 ]
 const validChooseClinicPageCombos: RoutingTestCombo[] = [
@@ -215,30 +221,40 @@ const validChooseClinicPageCombos: RoutingTestCombo[] = [
     validEligibility: 'valid',
     adjunctiveMatch: 'none',
     validIncome: 'valid',
-    error: false,
-    cause: '',
+    hasIssues: false,
+    showError: false,
+    redirect: '',
   },
   {
     validEligibility: 'valid',
     adjunctiveMatch: 'tanf',
     validIncome: 'valid',
-    error: false,
-    cause: '',
+    hasIssues: false,
+    showError: false,
+    redirect: '',
   },
   {
     validEligibility: 'valid',
     adjunctiveMatch: 'tanf',
     validIncome: 'invalid',
-    error: false,
-    cause: '',
+    hasIssues: false,
+    showError: false,
+    redirect: '',
   },
 ]
 const chooseClinicPageCombos = invalidChooseClinicPageCombos.concat(
   validChooseClinicPageCombos
 )
 it.each(chooseClinicPageCombos)(
-  '/choose-clinic should have issues ($error caused by $cause) with $validEligibility eligibility, adjunctive $adjunctiveMatch, $validIncome income',
-  ({ validEligibility, adjunctiveMatch, validIncome, error, cause }) => {
+  '/choose-clinic should have issues ($hasIssues caused by $redirect) with $validEligibility eligibility, adjunctive $adjunctiveMatch, $validIncome income',
+  ({
+    validEligibility,
+    adjunctiveMatch,
+    validIncome,
+    hasIssues,
+    showError,
+    redirect,
+  }) => {
     const mockSession = buildRoutingIssuesMockSession(
       validEligibility,
       adjunctiveMatch,
@@ -247,8 +263,9 @@ it.each(chooseClinicPageCombos)(
     const pathname = '/choose-clinic'
     singletonRouter.push(pathname)
     const outcome = hasRoutingIssues(pathname, mockSession)
-    expect(outcome.error).toBe(error)
-    expect(outcome.cause).toBe(cause)
+    expect(outcome.hasIssues).toBe(hasIssues)
+    expect(outcome.showError).toBe(showError)
+    expect(outcome.redirect).toBe(redirect)
   }
 )
 
@@ -271,16 +288,18 @@ const contactInvalidPreviousValid: RoutingTestCombo[] =
   validChooseClinicPageCombos.map((combo) => ({
     ...combo,
     validChooseClinic: 'invalid',
-    error: true,
-    cause: 'choose-clinic',
+    hasIssues: true,
+    showError: true,
+    redirect: 'choose-clinic',
   }))
 // /contact will only be valid if the previous pages are valid AND session.choose-clinic is valid.
 const validContactPageCombos: RoutingTestCombo[] =
   validChooseClinicPageCombos.map((combo) => ({
     ...combo,
     validChooseClinic: 'valid',
-    error: false,
-    cause: '',
+    hasIssues: false,
+    showError: false,
+    redirect: '',
   }))
 // Combine into one testing array.
 const invalidContactPageCombos = contactValidPreviousInvalid
@@ -290,14 +309,15 @@ const contactPageCombos = invalidContactPageCombos.concat(
   validContactPageCombos
 )
 it.each(contactPageCombos)(
-  '/contact should have issues ($error caused by $cause) with $validEligibility eligibility, adjunctive $adjunctiveMatch, $validIncome income, $validChooseClinic choose clinic',
+  '/contact should have issues ($hasIssues caused by $redirect) with $validEligibility eligibility, adjunctive $adjunctiveMatch, $validIncome income, $validChooseClinic choose clinic',
   ({
     validEligibility,
     adjunctiveMatch,
     validIncome,
     validChooseClinic,
-    error,
-    cause,
+    hasIssues,
+    showError,
+    redirect,
   }) => {
     const mockSession = buildRoutingIssuesMockSession(
       validEligibility,
@@ -308,8 +328,9 @@ it.each(contactPageCombos)(
     const pathname = '/contact'
     singletonRouter.push(pathname)
     const outcome = hasRoutingIssues(pathname, mockSession)
-    expect(outcome.error).toBe(error)
-    expect(outcome.cause).toBe(cause)
+    expect(outcome.hasIssues).toBe(hasIssues)
+    expect(outcome.showError).toBe(showError)
+    expect(outcome.redirect).toBe(redirect)
   }
 )
 
@@ -332,16 +353,18 @@ const reviewInvalidPreviousValid: RoutingTestCombo[] =
   validContactPageCombos.map((combo) => ({
     ...combo,
     validContact: 'invalid',
-    error: true,
-    cause: 'contact',
+    hasIssues: true,
+    showError: true,
+    redirect: 'contact',
   }))
 // /review will only be valid if the previous pages are valid AND session.contact is valid.
 const validReviewPageCombos: RoutingTestCombo[] = validContactPageCombos.map(
   (combo) => ({
     ...combo,
     validContact: 'valid',
-    error: false,
-    cause: '',
+    hasIssues: false,
+    showError: false,
+    redirect: '',
   })
 )
 // Combine into one testing array.
@@ -350,15 +373,16 @@ const invalidReviewPageCombos = reviewValidPreviousInvalid
   .concat(reviewInvalidPreviousValid)
 const reviewPageCombos = invalidReviewPageCombos.concat(validReviewPageCombos)
 it.each(reviewPageCombos)(
-  '/review should have issues ($error caused by $cause) with $validEligibility eligibility, adjunctive $adjunctiveMatch, $validIncome income, $validChooseClinic choose clinic $validContact contact',
+  '/review should have issues ($hasIssues caused by $redirect) with $validEligibility eligibility, adjunctive $adjunctiveMatch, $validIncome income, $validChooseClinic choose clinic $validContact contact',
   ({
     validEligibility,
     adjunctiveMatch,
     validIncome,
     validChooseClinic,
     validContact,
-    error,
-    cause,
+    hasIssues,
+    showError,
+    redirect,
   }) => {
     const mockSession = buildRoutingIssuesMockSession(
       validEligibility,
@@ -370,7 +394,43 @@ it.each(reviewPageCombos)(
     const pathname = '/review'
     singletonRouter.push(pathname)
     const outcome = hasRoutingIssues(pathname, mockSession)
-    expect(outcome.error).toBe(error)
-    expect(outcome.cause).toBe(cause)
+    expect(outcome.hasIssues).toBe(hasIssues)
+    expect(outcome.showError).toBe(showError)
+    expect(outcome.redirect).toBe(redirect)
+  }
+)
+
+// /confirmation is like /review except when it errors,
+// it always redirects to / and never shows an error.
+it.each(reviewPageCombos)(
+  '/confirmation should have issues ($hasIssues caused by $redirect) with $validEligibility eligibility, adjunctive $adjunctiveMatch, $validIncome income, $validChooseClinic choose clinic $validContact contact',
+  ({
+    validEligibility,
+    adjunctiveMatch,
+    validIncome,
+    validChooseClinic,
+    validContact,
+    hasIssues,
+    showError,
+    redirect,
+  }) => {
+    const mockSession = buildRoutingIssuesMockSession(
+      validEligibility,
+      adjunctiveMatch,
+      validIncome,
+      validChooseClinic,
+      validContact
+    )
+    const pathname = '/confirmation'
+    singletonRouter.push(pathname)
+    const outcome = hasRoutingIssues(pathname, mockSession)
+    expect(outcome.hasIssues).toBe(hasIssues)
+    expect(outcome.showError).toBe(false)
+
+    if (hasIssues) {
+      expect(outcome.redirect).toBe('/')
+    } else {
+      expect(outcome.redirect).toBe('')
+    }
   }
 )


### PR DESCRIPTION
## Ticket

https://wicmtdp.atlassian.net/browse/WMDP-269

## Changes
> What was added, updated, or removed in this PR.

- Change handling for /confirmation for when there is no user data to redirect to index page
- Add more nuanced handling of routing issues in custom app
- Extend `isValidSession()` to be a more generic data validation wrapper
- Update `hasRoutingIssues()` to support /confirmation logic

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

This change was surfaced as part of internal QA testing.

## Testing
> Screenshots, GIF demos, code examples or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

Incorrect page access flow:

1. Checkout this branch
2. Spin up the docker container: `docker-compose up -d --build`
3. Navigate to the confirmation page when you have no session data (localhost:3000/confirmation)
4. You should be redirected to the home page and no error message should be shown
5. Remove the docker container when you're done testing: `docker-compose down`

Hitting back button after form submission flow:

1. Checkout this branch
2. Spin up the docker container: `docker-compose up -d --build`
3. Fill out the entire form wizard and get to the confirmation page
4. Click "Start a new application" and get routed to the home page
6. Click the browser back button, which should land you back on the home page
5. Remove the docker container when you're done testing: `docker-compose down`