### PR TITLE
Add html page titles

### DIFF
--- a/app/public/locales/en/common.json
+++ b/app/public/locales/en/common.json
@@ -68,7 +68,7 @@
     "assistance": "Learn about other assistance",
     "enrolled": "If you or someone in your household are currently enrolled in <strong>Medicaid, Healthy Montana Kids Plus</strong>, Supplemental Nutrition Assistance Program (<strong>SNAP</strong>), Temporary Assistance for Needy Families (<strong>TANF</strong>), or Food Distribution Program on Indian Reservations (<strong>FDPIR</strong>), you may be automatically eligible for WIC.",
     "estimatedIncome": "Estimated maximum income limit before taxes",
-    "header": "Check your eligibility",
+    "header": "To be eligible for WIC, your <strong>household income before taxes</strong> must be <strong>at</strong> or <strong>below</strong> a certain income level.",
     "helper": "If someone in your household is pregnant and applying for WIC benefits and is determined to be ineligible based on your household income, you may then increase your household size by the number of expected births.",
     "householdSize": "Household size",
     "householdSizeHeader": "What is your household size?",
@@ -79,7 +79,7 @@
       "weekly": "Weekly"
     },
     "notEnrolled": "If you are not currently enrolled in one or more of those programs, you will have to show proof your income is within a certain level.",
-    "title": "To be eligible for WIC, your <strong>household income before taxes</strong> must be <strong>at</strong> or <strong>below</strong> a certain income level.",
+    "title": "Check your eligibility",
     "unsure": "<strong>If you are unsure about your income, please continue to apply.</strong> A WIC staff member can answer more specific questions about your situation."
   },
   "Index": {

--- a/app/src/components/PageTitle.tsx
+++ b/app/src/components/PageTitle.tsx
@@ -1,0 +1,45 @@
+import { useTranslation } from 'next-i18next'
+import Head from 'next/head'
+import { ReactElement } from 'react'
+
+export type PageTitleProps = {
+  pathname: string
+}
+
+const PageTitle = (props: PageTitleProps): ReactElement => {
+  const { pathname } = props
+  console.log(pathname)
+
+  const { t } = useTranslation('common')
+  let pageTitle = ''
+  let i18nPageKey = ''
+
+  // Handle the index page.
+  if (pathname === '/') {
+    i18nPageKey = 'Index'
+  }
+  // Convert all other pathnames to capital camel case to match i18n content file.
+  else {
+    i18nPageKey = pathname
+      .toLowerCase()
+      .replace(/([-_][a-z])/g, (group) =>
+        group.toUpperCase().replace('-', '').replace('_', '')
+      )
+      .replace(/^\/[a-z]/, (group) => group.replace('/', '').toUpperCase())
+  }
+
+  pageTitle = t(`${i18nPageKey}.title`)
+
+  // Fallback to the layout header if there is no page title found.
+  if (/\.title$/.test(pageTitle)) {
+    pageTitle = t('Layout.header')
+  }
+
+  return (
+    <Head>
+      <title>{pageTitle}</title>
+    </Head>
+  )
+}
+
+export default PageTitle

--- a/app/src/components/PageTitle.tsx
+++ b/app/src/components/PageTitle.tsx
@@ -8,7 +8,6 @@ export type PageTitleProps = {
 
 const PageTitle = (props: PageTitleProps): ReactElement => {
   const { pathname } = props
-  console.log(pathname)
 
   const { t } = useTranslation('common')
   let pageTitle = ''

--- a/app/src/pages/_app.tsx
+++ b/app/src/pages/_app.tsx
@@ -5,6 +5,7 @@ import { useEffect } from 'react'
 
 import Layout from '@components/Layout'
 import PageError from '@components/PageError'
+import PageTitle from '@components/PageTitle'
 
 import useSessionStorage from '@src/hooks/useSessionStorage'
 import '@styles/styles.scss'
@@ -67,6 +68,7 @@ function MyApp({ Component, pageProps }: AppProps) {
         {router.query.error === 'missing-data' && (
           <PageError alertBody="routingError" />
         )}
+        <PageTitle pathname={router.pathname} />
         <Component {...props} />
       </>
     </Layout>

--- a/app/src/pages/income.tsx
+++ b/app/src/pages/income.tsx
@@ -76,13 +76,13 @@ const Income: NextPage<EditablePage> = (props: EditablePage) => {
     <>
       <BackLink href={backRoute} />
       <h1>
-        <Trans i18nKey="Income.header" />
+        <Trans i18nKey="Income.title" />
       </h1>
       <RequiredQuestionStatement />
 
       <div className="content-group">
         <h2>
-          <Trans i18nKey="Income.title" />
+          <Trans i18nKey="Income.header" />
         </h2>
         <p>
           <Trans i18nKey="Income.enrolled" />


### PR DESCRIPTION
## Ticket

https://wicmtdp.atlassian.net/browse/WMDP-272

## Changes
> What was added, updated, or removed in this PR.

- Add `<PageTitle>` component to render an html page title for each page
- Fix inconsistent naming convention for page title on /income

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

Pages were missing a `<title>` element previously. 

## Testing
> Screenshots, GIF demos, code examples or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

1. Checkout this branch
2. Spin up the docker container: `docker-compose up -d --build`
3. Each page should display the `<h1>` as the page title
5. Remove the docker container when you're done testing: `docker-compose down`

Examples:
<img width="330" alt="Screen Shot 2022-11-28 at 3 47 55 PM" src="https://user-images.githubusercontent.com/67701/204404440-eb3c6611-7492-4502-8d35-41a4e11fbedc.png">
<img width="326" alt="Screen Shot 2022-11-28 at 3 48 04 PM" src="https://user-images.githubusercontent.com/67701/204404446-07cc0b7a-4a52-4f60-a3dd-70b5af9ed732.png">
