### PR TITLE
Storybook: display pages (esp index) before components.

### DIFF
--- a/app/.storybook/preview.js
+++ b/app/.storybook/preview.js
@@ -27,7 +27,6 @@ export const parameters = {
     storySort: {
       method: 'alphabetical',
       order: [
-        'Components',
         'Pages',
         [
           'Index',
@@ -39,6 +38,7 @@ export const parameters = {
           'Review',
           'Confirmation',
         ],
+        'Components',
       ],
     },
   },


### PR DESCRIPTION
## Ticket

N/A

## Changes
> What was added, updated, or removed in this PR.

- Sort storybook stories to focus on pages before atoms

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

Since we are [publicly sharing our Storybook](https://navapbc.github.io/wic-mt-demo-project-eligibility-screener/), we want the landing page to showcase a more interesting component. This PR rearranges the story categories to put Pages before Components.

## Testing
> Screenshots, GIF demos, code examples or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

1. Checkout this branch
2. Build and run the container: `docker-compose up -d --build`
3. Build and run storybook: `docker-compose exec nextjs yarn storybook`
4. Navigate to localhost:6006
5. Confirm that the landing page is the MWDP index page and not the Accordion component
6. Remove the container when you're done: `docker-compose down`