### PR TITLE
Remove extraneous ReactElement typescript notations.

### DIFF
--- a/app/src/components/Accordion.tsx
+++ b/app/src/components/Accordion.tsx
@@ -1,5 +1,5 @@
 import { Trans } from 'next-i18next'
-import { ReactElement, useState } from 'react'
+import { useState } from 'react'
 
 import { i18nKey } from '@src/types'
 
@@ -8,7 +8,7 @@ export type AccordionProps = {
   headerKey: i18nKey
 }
 
-const Accordion = (props: AccordionProps): ReactElement => {
+const Accordion = (props: AccordionProps) => {
   const { bodyKey, headerKey } = props
   const [isExpanded, setExpanded] = useState(false)
 

--- a/app/src/components/Alert.tsx
+++ b/app/src/components/Alert.tsx
@@ -1,5 +1,4 @@
 import { Trans } from 'next-i18next'
-import { ReactElement } from 'react'
 
 import { i18nKey } from '@src/types'
 
@@ -11,7 +10,7 @@ export type AlertProps = {
   icon?: boolean
 }
 
-export const Alert = (props: AlertProps): ReactElement => {
+export const Alert = (props: AlertProps) => {
   const { alertBody, type, icon } = props
 
   return (

--- a/app/src/components/BackLink.tsx
+++ b/app/src/components/BackLink.tsx
@@ -1,12 +1,10 @@
-import { ReactElement } from 'react'
-
 import StyledLink from '@components/StyledLink'
 
 export type BackLinkProps = {
   href: string
 }
 
-export const BackLink = (props: BackLinkProps): ReactElement => {
+export const BackLink = (props: BackLinkProps) => {
   const { href } = props
   return <StyledLink textKey="backlinkText" href={href} external={false} />
 }

--- a/app/src/components/Button.tsx
+++ b/app/src/components/Button.tsx
@@ -1,5 +1,5 @@
 import { Trans } from 'next-i18next'
-import React, { MouseEvent, ReactElement } from 'react'
+import React, { MouseEvent } from 'react'
 
 import { i18nKey } from '@src/types'
 
@@ -25,10 +25,7 @@ export type ButtonProps = {
 // be a child component of next/link. For more info, see
 // https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-functional-component
 const Button = React.forwardRef(
-  (
-    props: ButtonProps,
-    ref: React.LegacyRef<HTMLButtonElement>
-  ): ReactElement => {
+  (props: ButtonProps, ref: React.LegacyRef<HTMLButtonElement>) => {
     const { disabled, labelKey, style, onClick } = props
 
     let buttonStyle = ''

--- a/app/src/components/ButtonLink.tsx
+++ b/app/src/components/ButtonLink.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { MouseEvent, ReactElement } from 'react'
+import { MouseEvent } from 'react'
 import { UrlObject } from 'url'
 
 import Button from '@components/Button'
@@ -14,7 +14,7 @@ export type ButtonLinkProps = {
   onClick?: (e: MouseEvent<HTMLElement>) => void
 }
 
-const ButtonLink = (props: ButtonLinkProps): ReactElement => {
+const ButtonLink = (props: ButtonLinkProps) => {
   const { disabled, href, labelKey, style, onClick } = props
 
   return (

--- a/app/src/components/ClinicInfo.tsx
+++ b/app/src/components/ClinicInfo.tsx
@@ -1,5 +1,3 @@
-import { ReactElement } from 'react'
-
 export type ClinicInfoProps = {
   name: string
   streetAddress: string
@@ -7,7 +5,7 @@ export type ClinicInfoProps = {
   isFormElement?: boolean
 }
 
-export const ClinicInfo = (props: ClinicInfoProps): ReactElement => {
+export const ClinicInfo = (props: ClinicInfoProps) => {
   const { name, streetAddress, phone, isFormElement = false } = props
 
   const formClass = isFormElement ? 'usa-checkbox__label-description' : ''

--- a/app/src/components/ClinicSelectionList.tsx
+++ b/app/src/components/ClinicSelectionList.tsx
@@ -1,11 +1,5 @@
 import { Trans } from 'next-i18next'
-import {
-  ChangeEvent,
-  Dispatch,
-  MouseEvent,
-  ReactElement,
-  SetStateAction,
-} from 'react'
+import { ChangeEvent, Dispatch, MouseEvent, SetStateAction } from 'react'
 
 import Button from '@components/Button'
 import ButtonLink, { ButtonLinkProps } from '@components/ButtonLink'
@@ -24,7 +18,7 @@ export type ClinicSelectionListProps = {
   actionButton: ButtonLinkProps
 }
 
-const ClinicSelectionList = (props: ClinicSelectionListProps): ReactElement => {
+const ClinicSelectionList = (props: ClinicSelectionListProps) => {
   const {
     filteredClinics,
     expandList,
@@ -42,7 +36,7 @@ const ClinicSelectionList = (props: ClinicSelectionListProps): ReactElement => {
     setExpandList(true)
   }
 
-  let list: ReactElement = <></>
+  let list = <></>
   if (filteredClinics.length > 0) {
     list = (
       <>

--- a/app/src/components/Dropdown.tsx
+++ b/app/src/components/Dropdown.tsx
@@ -1,5 +1,5 @@
 import { Trans } from 'next-i18next'
-import { ChangeEvent, ReactElement } from 'react'
+import { ChangeEvent } from 'react'
 
 import Required from '@components/Required'
 
@@ -16,7 +16,7 @@ export interface DropdownProps {
 
 // @TODO: This component expects pre-translated option strings.
 //        It should be refactored if itos ever used with non-integer options.
-const Dropdown = (props: DropdownProps): ReactElement => {
+const Dropdown = (props: DropdownProps) => {
   const { handleChange, id, labelKey, options, required, selectedOption } =
     props
 

--- a/app/src/components/IncomeRow.tsx
+++ b/app/src/components/IncomeRow.tsx
@@ -1,5 +1,3 @@
-import { ReactElement } from 'react'
-
 export type IncomeRowProps = {
   periods: string[]
   householdSize: string
@@ -8,7 +6,7 @@ export type IncomeRowProps = {
   }
 }
 
-const IncomeRow = (props: IncomeRowProps): ReactElement => {
+const IncomeRow = (props: IncomeRowProps) => {
   const { periods, householdSize, incomeForHouseholdSize } = props
 
   // If the householdSize is not an empty string, then use it

--- a/app/src/components/InputChoiceGroup.tsx
+++ b/app/src/components/InputChoiceGroup.tsx
@@ -1,5 +1,5 @@
 import { Trans } from 'next-i18next'
-import { ChangeEvent, ReactElement } from 'react'
+import { ChangeEvent } from 'react'
 
 import Accordion from '@components/Accordion'
 import Required from '@components/Required'
@@ -25,7 +25,7 @@ export type InputChoiceGroupProps = {
   type: 'checkbox' | 'radio'
 }
 
-const InputChoiceGroup = (props: InputChoiceGroupProps): ReactElement => {
+const InputChoiceGroup = (props: InputChoiceGroupProps) => {
   const { accordion, choices, titleKey, required, type } = props
 
   return (

--- a/app/src/components/Layout.tsx
+++ b/app/src/components/Layout.tsx
@@ -6,7 +6,7 @@ type Props = {
   children: ReactElement
 }
 
-const Layout = ({ children }: Props): ReactElement => {
+const Layout = ({ children }: Props) => {
   return (
     <div className="container">
       <header className="header usa-header usa-header--basic" role="banner">

--- a/app/src/components/List.tsx
+++ b/app/src/components/List.tsx
@@ -1,5 +1,4 @@
 import { Trans } from 'next-i18next'
-import { ReactElement } from 'react'
 
 import { i18nKey } from '@src/types'
 
@@ -7,7 +6,7 @@ export type ListProps = {
   i18nKeys: i18nKey[]
 }
 
-export const List = (props: ListProps): ReactElement => {
+export const List = (props: ListProps) => {
   const { i18nKeys } = props
 
   return (

--- a/app/src/components/PageError.tsx
+++ b/app/src/components/PageError.tsx
@@ -1,5 +1,3 @@
-import { ReactElement } from 'react'
-
 import Alert from '@components/Alert'
 
 import { i18nKey } from '@src/types'
@@ -8,7 +6,7 @@ export type PageErrorProps = {
   alertBody: i18nKey
 }
 
-export const PageError = (props: PageErrorProps): ReactElement => {
+export const PageError = (props: PageErrorProps) => {
   const { alertBody } = props
   return (
     <div className="margin-bottom-3">

--- a/app/src/components/Required.tsx
+++ b/app/src/components/Required.tsx
@@ -1,6 +1,4 @@
-import { ReactElement } from 'react'
-
-export const Required = (): ReactElement => {
+export const Required = () => {
   return <abbr className="usa-hint usa-hint--required"> *</abbr>
 }
 

--- a/app/src/components/RequiredQuestionStatement.tsx
+++ b/app/src/components/RequiredQuestionStatement.tsx
@@ -1,7 +1,6 @@
 import { Trans } from 'next-i18next'
-import { ReactElement } from 'react'
 
-export const RequiredQuestionStatement = (): ReactElement => {
+export const RequiredQuestionStatement = () => {
   return (
     <p>
       <Trans i18nKey="asterisk" /> (

--- a/app/src/components/ReviewCollection.tsx
+++ b/app/src/components/ReviewCollection.tsx
@@ -1,5 +1,4 @@
 import { Trans } from 'next-i18next'
-import { ReactElement } from 'react'
 import { UrlObject } from 'url'
 
 import ButtonLink from '@components/ButtonLink'
@@ -15,7 +14,7 @@ export type ReviewCollectionProps = {
   firstElement?: boolean
 }
 
-const ReviewCollection = (props: ReviewCollectionProps): ReactElement => {
+const ReviewCollection = (props: ReviewCollectionProps) => {
   const {
     headerKey,
     reviewElements,

--- a/app/src/components/ReviewElement.tsx
+++ b/app/src/components/ReviewElement.tsx
@@ -8,7 +8,7 @@ export type ReviewElementProps = {
   children: ReactElement | string | null
 }
 
-const ReviewElement = (props: ReviewElementProps): ReactElement => {
+const ReviewElement = (props: ReviewElementProps) => {
   const { labelKey, children } = props
 
   return (

--- a/app/src/components/ReviewSection.tsx
+++ b/app/src/components/ReviewSection.tsx
@@ -1,5 +1,4 @@
 import { Trans } from 'next-i18next'
-import { ReactElement } from 'react'
 
 import ClinicInfo from '@components/ClinicInfo'
 import List from '@components/List'
@@ -20,7 +19,7 @@ export type ReviewSectionProps = {
   session: SessionData
 }
 
-const ReviewSection = (props: ReviewSectionProps): ReactElement => {
+const ReviewSection = (props: ReviewSectionProps) => {
   const { editable, session } = props
 
   const reviewMode = { mode: 'review' }

--- a/app/src/components/StyledLink.tsx
+++ b/app/src/components/StyledLink.tsx
@@ -1,6 +1,5 @@
 import { Trans } from 'next-i18next'
 import Link from 'next/link'
-import { ReactElement } from 'react'
 
 import { i18nKey } from '@src/types'
 
@@ -10,7 +9,7 @@ export type StyledLinkProps = {
   external?: boolean
 }
 
-export const StyledLink = (props: StyledLinkProps): ReactElement => {
+export const StyledLink = (props: StyledLinkProps) => {
   const { href, textKey, external = false } = props
   if (external) {
     return (

--- a/app/src/components/TextField.tsx
+++ b/app/src/components/TextField.tsx
@@ -1,5 +1,5 @@
 import { Trans } from 'next-i18next'
-import { ChangeEvent, ReactElement } from 'react'
+import { ChangeEvent } from 'react'
 
 import Required from '@components/Required'
 
@@ -16,9 +16,9 @@ export type TextFieldProps = {
   value: string
 }
 
-const TextField = (props: TextFieldProps): ReactElement => {
+const TextField = (props: TextFieldProps) => {
   const { handleChange, id, labelKey, required, type, value } = props
-  let textfield: ReactElement
+  let textfield = <></>
   if (type === 'textarea') {
     textfield = (
       <textarea


### PR DESCRIPTION
## Ticket

N/A

## Changes
> What was added, updated, or removed in this PR.

- Remove extraneous typescript notations for components explicitly stating the return as `ReactElement`

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

This PR follows up on an earlier PR [discussion](https://github.com/navapbc/wic-mt-demo-project-eligibility-screener/pull/146#discussion_r1009623337) where I learned that we don't need to explicitly notate that components are returning a `ReactElement` since typescript can easily infer this.

## Testing
> Screenshots, GIF demos, code examples or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

- `yarn test` and `yarn ts-check` for regression testing