### PR TITLE
Simplify snapshot testing

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -47,7 +47,6 @@
     "@types/node": "^18.7.18",
     "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.4",
-    "@types/react-test-renderer": "^18.0.0",
     "@types/styled-components": "^5.1.25",
     "@types/testing-library__jest-dom": "^5.14.3",
     "@types/testing-library__react": "^10.2.0",

--- a/app/tests/components/Accordion.test.tsx
+++ b/app/tests/components/Accordion.test.tsx
@@ -3,7 +3,6 @@ import { render, screen } from '@testing-library/react'
 import Accordion from '@components/Accordion'
 
 import { setupUserEvent } from '../helpers/setup'
-import { testSnapshot } from '../helpers/sharedTests'
 
 const testProps = {
   bodyKey: 'body',
@@ -11,7 +10,8 @@ const testProps = {
 }
 
 it('should match snapshot', () => {
-  testSnapshot(<Accordion {...testProps} />)
+  const { container } = render(<Accordion {...testProps} />)
+  expect(container).toMatchSnapshot()
 })
 
 it('should expand the accordion on click', async () => {

--- a/app/tests/components/Alert.test.tsx
+++ b/app/tests/components/Alert.test.tsx
@@ -2,8 +2,6 @@ import { render, screen } from '@testing-library/react'
 
 import Alert, { AlertProps, AlertTypes } from '@components/Alert'
 
-import { testSnapshot } from '../helpers/sharedTests'
-
 const testProps: AlertProps = {
   alertBody: 'body',
   type: 'info',
@@ -17,8 +15,8 @@ const alertTypes: Array<AlertTypes[]> = [
 ]
 
 it.each(alertTypes)('should match snapshot for %s alerts', (type) => {
-  const element = <Alert {...testProps} type={type} />
-  testSnapshot(element)
+  const { container } = render(<Alert {...testProps} type={type} />)
+  expect(container).toMatchSnapshot()
 })
 
 it.each(alertTypes)(

--- a/app/tests/components/BackLink.test.tsx
+++ b/app/tests/components/BackLink.test.tsx
@@ -2,8 +2,7 @@ import { render, screen } from '@testing-library/react'
 
 import BackLink from '@components/BackLink'
 
-import { testSnapshot } from '../helpers/sharedTests'
-
 it('should match snapshot', () => {
-  testSnapshot(<BackLink href="/" />)
+  const { container } = render(<BackLink href="/" />)
+  expect(container).toMatchSnapshot()
 })

--- a/app/tests/components/Button.test.tsx
+++ b/app/tests/components/Button.test.tsx
@@ -2,14 +2,13 @@ import { render, screen } from '@testing-library/react'
 
 import Button, { buttonStyleOptions } from '@components/Button'
 
-import { testSnapshot } from '../helpers/sharedTests'
-
 const styleOptions = buttonStyleOptions.map((style) => [style])
 
 it.each(styleOptions)('should match snapshot for %s style', (style) => {
-  testSnapshot(
+  const { container } = render(
     <Button disabled={false} labelKey="button label" style={style} />
   )
+  expect(container).toMatchSnapshot()
 })
 
 it.each(styleOptions)(

--- a/app/tests/components/ClinicInfo.test.tsx
+++ b/app/tests/components/ClinicInfo.test.tsx
@@ -2,8 +2,6 @@ import { render, screen } from '@testing-library/react'
 
 import ClinicInfo from '@components/ClinicInfo'
 
-import { testSnapshot } from '../helpers/sharedTests'
-
 const testProps = {
   name: 'clinic name',
   streetAddress: 'clinic address',
@@ -12,9 +10,15 @@ const testProps = {
 }
 
 it('should match snapshot when it is a form element', () => {
-  testSnapshot(<ClinicInfo {...testProps} isFormElement={true} />)
+  const { container } = render(
+    <ClinicInfo {...testProps} isFormElement={true} />
+  )
+  expect(container).toMatchSnapshot()
 })
 
 it('should match snapshot when it is not a form element', () => {
-  testSnapshot(<ClinicInfo {...testProps} isFormElement={false} />)
+  const { container } = render(
+    <ClinicInfo {...testProps} isFormElement={false} />
+  )
+  expect(container).toMatchSnapshot()
 })

--- a/app/tests/components/ClinicSelectionList.test.tsx
+++ b/app/tests/components/ClinicSelectionList.test.tsx
@@ -10,7 +10,6 @@ import cloneDeep from 'lodash/cloneDeep'
 import ClinicSelectionList from '@components/ClinicSelectionList'
 
 import { getMockClinic, setupClinicMocks } from '../helpers/setupClinics'
-import { testSnapshot } from '../helpers/sharedTests'
 
 setupClinicMocks()
 const mockSelectedClinic = getMockClinic()
@@ -31,15 +30,22 @@ const testProps = {
  * Begin tests
  */
 it('should match snapshot if the list is not expanded', () => {
-  testSnapshot(<ClinicSelectionList {...testProps} />)
+  const { container } = render(<ClinicSelectionList {...testProps} />)
+  expect(container).toMatchSnapshot()
 })
 
 it('should match snapshot if the list is expanded', () => {
-  testSnapshot(<ClinicSelectionList {...testProps} expandList={true} />)
+  const { container } = render(
+    <ClinicSelectionList {...testProps} expandList={true} />
+  )
+  expect(container).toMatchSnapshot()
 })
 
 it('should match snapshot if the list is empty', () => {
-  testSnapshot(<ClinicSelectionList {...testProps} filteredClinics={[]} />)
+  const { container } = render(
+    <ClinicSelectionList {...testProps} filteredClinics={[]} />
+  )
+  expect(container).toMatchSnapshot()
 })
 
 it('should display the right number of clinics if the list is not expanded', () => {

--- a/app/tests/components/Dropdown.test.tsx
+++ b/app/tests/components/Dropdown.test.tsx
@@ -2,8 +2,6 @@ import { render, screen } from '@testing-library/react'
 
 import Dropdown, { DropdownProps } from '@components/Dropdown'
 
-import { testSnapshot } from '../helpers/sharedTests'
-
 const testProps: DropdownProps = {
   handleChange: (e) => {},
   id: 'test-id',
@@ -12,7 +10,8 @@ const testProps: DropdownProps = {
 }
 
 it('should match snapshot', () => {
-  testSnapshot(<Dropdown {...testProps} />)
+  const { container } = render(<Dropdown {...testProps} />)
+  expect(container).toMatchSnapshot()
 })
 
 it('should match display required marker if required is true', () => {

--- a/app/tests/components/IncomeRow.test.tsx
+++ b/app/tests/components/IncomeRow.test.tsx
@@ -2,8 +2,6 @@ import { render, screen } from '@testing-library/react'
 
 import IncomeRow from '@components/IncomeRow'
 
-import { testSnapshot } from '../helpers/sharedTests'
-
 const testProps = {
   periods: ['weekly', 'monthly', 'annual'],
   householdSize: '1',
@@ -15,9 +13,11 @@ const testProps = {
 }
 
 it('should match snapshot when householdSize is not empty string', () => {
-  testSnapshot(<IncomeRow {...testProps} />)
+  const { container } = render(<IncomeRow {...testProps} />)
+  expect(container).toMatchSnapshot()
 })
 
 it('should match snapshot when householdSize is an empty string', () => {
-  testSnapshot(<IncomeRow {...testProps} householdSize="" />)
+  const { container } = render(<IncomeRow {...testProps} householdSize="" />)
+  expect(container).toMatchSnapshot()
 })

--- a/app/tests/components/InputChoiceGroup.test.tsx
+++ b/app/tests/components/InputChoiceGroup.test.tsx
@@ -5,8 +5,6 @@ import InputChoiceGroup, {
   InputChoiceGroupProps,
 } from '@components/InputChoiceGroup'
 
-import { testSnapshot } from '../helpers/sharedTests'
-
 const choices = [
   {
     checked: false,
@@ -39,11 +37,13 @@ const testProps: InputChoiceGroupProps = {
 }
 
 it('should match snapshot when it is a set of checkboxes', () => {
-  testSnapshot(<InputChoiceGroup {...testProps} />)
+  const { container } = render(<InputChoiceGroup {...testProps} />)
+  expect(container).toMatchSnapshot()
 })
 
 it('should match snapshot when it is a set of radio buttons', () => {
-  testSnapshot(<InputChoiceGroup {...testProps} type="radio" />)
+  const { container } = render(<InputChoiceGroup {...testProps} type="radio" />)
+  expect(container).toMatchSnapshot()
 })
 
 it('should match display required marker if required is true', () => {

--- a/app/tests/components/Layout.test.tsx
+++ b/app/tests/components/Layout.test.tsx
@@ -1,9 +1,12 @@
+import { render } from '@testing-library/react'
+
 import Layout from '@components/Layout'
 
-import { testAccessibility, testSnapshot } from '../helpers/sharedTests'
+import { testAccessibility } from '../helpers/sharedTests'
 
 it('should match snapshot', () => {
-  testSnapshot(<Layout children={<h1>'child'</h1>} />)
+  const { container } = render(<Layout children={<h1>'child'</h1>} />)
+  expect(container).toMatchSnapshot()
 })
 
 it('should pass accessibility scan', async () => {

--- a/app/tests/components/List.test.tsx
+++ b/app/tests/components/List.test.tsx
@@ -1,11 +1,12 @@
-import List from '@components/List'
+import { render } from '@testing-library/react'
 
-import { testSnapshot } from '../helpers/sharedTests'
+import List from '@components/List'
 
 const testProps = {
   i18nKeys: ['list item a', 'list item b', 'list item c'],
 }
 
 it('should match snapshot', () => {
-  testSnapshot(<List {...testProps} />)
+  const { container } = render(<List {...testProps} />)
+  expect(container).toMatchSnapshot()
 })

--- a/app/tests/components/PageError.test.tsx
+++ b/app/tests/components/PageError.test.tsx
@@ -1,7 +1,8 @@
+import { render } from '@testing-library/react'
+
 import PageError from '@components/PageError'
 
-import { testSnapshot } from '../helpers/sharedTests'
-
 it('should match snapshot', () => {
-  testSnapshot(<PageError alertBody="alert body text" />)
+  const { container } = render(<PageError alertBody="alert body text" />)
+  expect(container).toMatchSnapshot()
 })

--- a/app/tests/components/Required.test.tsx
+++ b/app/tests/components/Required.test.tsx
@@ -1,7 +1,8 @@
+import { render } from '@testing-library/react'
+
 import Required from '@components/Required'
 
-import { testSnapshot } from '../helpers/sharedTests'
-
 it('should match snapshot', () => {
-  testSnapshot(<Required />)
+  const { container } = render(<Required />)
+  expect(container).toMatchSnapshot()
 })

--- a/app/tests/components/RequiredQuestionStatement.test.tsx
+++ b/app/tests/components/RequiredQuestionStatement.test.tsx
@@ -1,7 +1,8 @@
+import { render } from '@testing-library/react'
+
 import RequiredQuestionStatement from '@components/RequiredQuestionStatement'
 
-import { testSnapshot } from '../helpers/sharedTests'
-
 it('should match snapshot', () => {
-  testSnapshot(<RequiredQuestionStatement />)
+  const { container } = render(<RequiredQuestionStatement />)
+  expect(container).toMatchSnapshot()
 })

--- a/app/tests/components/ReviewCollection.test.tsx
+++ b/app/tests/components/ReviewCollection.test.tsx
@@ -2,8 +2,6 @@ import { render, screen } from '@testing-library/react'
 
 import ReviewCollection from '@components/ReviewCollection'
 
-import { testSnapshot } from '../helpers/sharedTests'
-
 const reviewElements = [
   { labelKey: 'element a', children: 'child a' },
   { labelKey: 'element b', children: 'child b' },
@@ -18,9 +16,15 @@ const testProps = {
 }
 
 it('should match snapshot when it is the first element', () => {
-  testSnapshot(<ReviewCollection {...testProps} firstElement={true} />)
+  const { container } = render(
+    <ReviewCollection {...testProps} firstElement={true} />
+  )
+  expect(container).toMatchSnapshot()
 })
 
 it('should match snapshot when it is not the first element', () => {
-  testSnapshot(<ReviewCollection {...testProps} firstElement={false} />)
+  const { container } = render(
+    <ReviewCollection {...testProps} firstElement={false} />
+  )
+  expect(container).toMatchSnapshot()
 })

--- a/app/tests/components/ReviewElement.test.tsx
+++ b/app/tests/components/ReviewElement.test.tsx
@@ -2,13 +2,11 @@ import { render, screen } from '@testing-library/react'
 
 import ReviewElement from '@components/ReviewElement'
 
-import { testSnapshot } from '../helpers/sharedTests'
-
 it('should match snapshot', () => {
-  const element = (
+  const { container } = render(
     <ReviewElement labelKey="label">This is a child</ReviewElement>
   )
-  testSnapshot(element)
+  expect(container).toMatchSnapshot()
 })
 
 it('should render children', () => {

--- a/app/tests/components/StyledLink.test.tsx
+++ b/app/tests/components/StyledLink.test.tsx
@@ -1,6 +1,6 @@
-import StyledLink from '@components/StyledLink'
+import { render } from '@testing-library/react'
 
-import { testSnapshot } from '../helpers/sharedTests'
+import StyledLink from '@components/StyledLink'
 
 const testProps = {
   href: '/somewhere',
@@ -9,11 +9,11 @@ const testProps = {
 }
 
 it('should match snapshot for internal link', () => {
-  const element = <StyledLink {...testProps} />
-  testSnapshot(element)
+  const { container } = render(<StyledLink {...testProps} />)
+  expect(container).toMatchSnapshot()
 })
 
 it('should match snapshot for external link', () => {
-  const element = <StyledLink {...testProps} external={true} />
-  testSnapshot(element)
+  const { container } = render(<StyledLink {...testProps} external={true} />)
+  expect(container).toMatchSnapshot()
 })

--- a/app/tests/components/TextField.test.tsx
+++ b/app/tests/components/TextField.test.tsx
@@ -3,8 +3,6 @@ import { ChangeEvent } from 'react'
 
 import TextField from '@components/TextField'
 
-import { testSnapshot } from '../helpers/sharedTests'
-
 const testProps = {
   handleChange: (
     e: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLTextAreaElement>
@@ -16,11 +14,13 @@ const testProps = {
 }
 
 it('should match snapshot when it is a textfield', () => {
-  testSnapshot(<TextField {...testProps} type="input" />)
+  const { container } = render(<TextField {...testProps} type="input" />)
+  expect(container).toMatchSnapshot()
 })
 
 it('should match snapshot when it is a textarea', () => {
-  testSnapshot(<TextField {...testProps} type="textarea" />)
+  const { container } = render(<TextField {...testProps} type="textarea" />)
+  expect(container).toMatchSnapshot()
 })
 
 it('should be a textfield by default', () => {

--- a/app/tests/components/__snapshots__/Accordion.test.tsx.snap
+++ b/app/tests/components/__snapshots__/Accordion.test.tsx.snap
@@ -1,28 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should match snapshot 1`] = `
-<div
-  className="usa-accordion usa-accordion--bordered"
->
-  <h3
-    className="usa-accordion__heading"
-  >
-    <button
-      aria-controls="b-a1"
-      aria-expanded={false}
-      className="usa-accordion__button"
-      onClick={[Function]}
-      type="button"
-    >
-      header
-    </button>
-  </h3>
+<div>
   <div
-    className="usa-accordion__content"
-    hidden={true}
-    id="b-a1"
+    class="usa-accordion usa-accordion--bordered"
   >
-    body
+    <h3
+      class="usa-accordion__heading"
+    >
+      <button
+        aria-controls="b-a1"
+        aria-expanded="false"
+        class="usa-accordion__button"
+        type="button"
+      >
+        header
+      </button>
+    </h3>
+    <div
+      class="usa-accordion__content"
+      hidden=""
+      id="b-a1"
+    >
+      body
+    </div>
   </div>
 </div>
 `;

--- a/app/tests/components/__snapshots__/Alert.test.tsx.snap
+++ b/app/tests/components/__snapshots__/Alert.test.tsx.snap
@@ -1,69 +1,77 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should match snapshot for error alerts 1`] = `
-<div
-  className="usa-alert usa-alert--error usa-alert--no-icon"
-  role="alert"
->
+<div>
   <div
-    className="usa-alert__body"
+    class="usa-alert usa-alert--error usa-alert--no-icon"
+    role="alert"
   >
-    <p
-      className="usa-alert__text"
+    <div
+      class="usa-alert__body"
     >
-      body
-    </p>
+      <p
+        class="usa-alert__text"
+      >
+        body
+      </p>
+    </div>
   </div>
 </div>
 `;
 
 exports[`should match snapshot for info alerts 1`] = `
-<div
-  className="usa-alert usa-alert--info usa-alert--no-icon"
-  role="alert"
->
+<div>
   <div
-    className="usa-alert__body"
+    class="usa-alert usa-alert--info usa-alert--no-icon"
+    role="alert"
   >
-    <p
-      className="usa-alert__text"
+    <div
+      class="usa-alert__body"
     >
-      body
-    </p>
+      <p
+        class="usa-alert__text"
+      >
+        body
+      </p>
+    </div>
   </div>
 </div>
 `;
 
 exports[`should match snapshot for success alerts 1`] = `
-<div
-  className="usa-alert usa-alert--success usa-alert--no-icon"
-  role="alert"
->
+<div>
   <div
-    className="usa-alert__body"
+    class="usa-alert usa-alert--success usa-alert--no-icon"
+    role="alert"
   >
-    <p
-      className="usa-alert__text"
+    <div
+      class="usa-alert__body"
     >
-      body
-    </p>
+      <p
+        class="usa-alert__text"
+      >
+        body
+      </p>
+    </div>
   </div>
 </div>
 `;
 
 exports[`should match snapshot for warning alerts 1`] = `
-<div
-  className="usa-alert usa-alert--warning usa-alert--no-icon"
-  role="alert"
->
+<div>
   <div
-    className="usa-alert__body"
+    class="usa-alert usa-alert--warning usa-alert--no-icon"
+    role="alert"
   >
-    <p
-      className="usa-alert__text"
+    <div
+      class="usa-alert__body"
     >
-      body
-    </p>
+      <p
+        class="usa-alert__text"
+      >
+        body
+      </p>
+    </div>
   </div>
 </div>
 `;

--- a/app/tests/components/__snapshots__/BackLink.test.tsx.snap
+++ b/app/tests/components/__snapshots__/BackLink.test.tsx.snap
@@ -1,13 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should match snapshot 1`] = `
-<a
-  className="usa-link"
-  href="/"
-  onClick={[Function]}
-  onMouseEnter={[Function]}
-  onTouchStart={[Function]}
->
-  Back
-</a>
+<div>
+  <a
+    class="usa-link"
+    href="/"
+  >
+    Back
+  </a>
+</div>
 `;

--- a/app/tests/components/__snapshots__/Button.test.tsx.snap
+++ b/app/tests/components/__snapshots__/Button.test.tsx.snap
@@ -1,73 +1,81 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should match snapshot for accent-cool style 1`] = `
-<button
-  className="usa-button usa-button--small display-block usa-button--accent-cool margin-top-1"
-  disabled={false}
->
-  button label
-</button>
+<div>
+  <button
+    class="usa-button usa-button--small display-block usa-button--accent-cool margin-top-1"
+  >
+    button label
+  </button>
+</div>
 `;
 
 exports[`should match snapshot for accent-warm style 1`] = `
-<button
-  className="usa-button usa-button--small display-block usa-button--accent-warm margin-top-1"
-  disabled={false}
->
-  button label
-</button>
+<div>
+  <button
+    class="usa-button usa-button--small display-block usa-button--accent-warm margin-top-1"
+  >
+    button label
+  </button>
+</div>
 `;
 
 exports[`should match snapshot for base style 1`] = `
-<button
-  className="usa-button usa-button--small display-block usa-button--base margin-top-1"
-  disabled={false}
->
-  button label
-</button>
+<div>
+  <button
+    class="usa-button usa-button--small display-block usa-button--base margin-top-1"
+  >
+    button label
+  </button>
+</div>
 `;
 
 exports[`should match snapshot for big style 1`] = `
-<button
-  className="usa-button usa-button--small display-block usa-button--big margin-top-1"
-  disabled={false}
->
-  button label
-</button>
+<div>
+  <button
+    class="usa-button usa-button--small display-block usa-button--big margin-top-1"
+  >
+    button label
+  </button>
+</div>
 `;
 
 exports[`should match snapshot for default style 1`] = `
-<button
-  className="usa-button usa-button--small display-block margin-top-6"
-  disabled={false}
->
-  button label
-</button>
+<div>
+  <button
+    class="usa-button usa-button--small display-block margin-top-6"
+  >
+    button label
+  </button>
+</div>
 `;
 
 exports[`should match snapshot for outline style 1`] = `
-<button
-  className="usa-button usa-button--small display-block usa-button--outline margin-top-1"
-  disabled={false}
->
-  button label
-</button>
+<div>
+  <button
+    class="usa-button usa-button--small display-block usa-button--outline margin-top-1"
+  >
+    button label
+  </button>
+</div>
 `;
 
 exports[`should match snapshot for secondary style 1`] = `
-<button
-  className="usa-button usa-button--small display-block usa-button--secondary margin-top-1"
-  disabled={false}
->
-  button label
-</button>
+<div>
+  <button
+    class="usa-button usa-button--small display-block usa-button--secondary margin-top-1"
+  >
+    button label
+  </button>
+</div>
 `;
 
 exports[`should match snapshot for unstyled style 1`] = `
-<button
-  className="usa-button usa-button--small display-block usa-button--unstyled margin-top-1"
-  disabled={false}
->
-  button label
-</button>
+<div>
+  <button
+    class="usa-button usa-button--small display-block usa-button--unstyled margin-top-1"
+  >
+    button label
+  </button>
+</div>
 `;

--- a/app/tests/components/__snapshots__/ClinicInfo.test.tsx.snap
+++ b/app/tests/components/__snapshots__/ClinicInfo.test.tsx.snap
@@ -1,52 +1,56 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should match snapshot when it is a form element 1`] = `
-<div
-  className="clinic-info"
->
+<div>
   <div
-    className="clinic-name"
-  >
-    clinic name
-  </div>
-  <div
-    className="usa-checkbox__label-description"
+    class="clinic-info"
   >
     <div
-      className="clinic-street-address"
+      class="clinic-name"
     >
-      clinic address
+      clinic name
     </div>
     <div
-      className="clinic-phone"
+      class="usa-checkbox__label-description"
     >
-      clinic phone
+      <div
+        class="clinic-street-address"
+      >
+        clinic address
+      </div>
+      <div
+        class="clinic-phone"
+      >
+        clinic phone
+      </div>
     </div>
   </div>
 </div>
 `;
 
 exports[`should match snapshot when it is not a form element 1`] = `
-<div
-  className="clinic-info"
->
+<div>
   <div
-    className="clinic-name"
-  >
-    clinic name
-  </div>
-  <div
-    className=""
+    class="clinic-info"
   >
     <div
-      className="clinic-street-address"
+      class="clinic-name"
     >
-      clinic address
+      clinic name
     </div>
     <div
-      className="clinic-phone"
+      class=""
     >
-      clinic phone
+      <div
+        class="clinic-street-address"
+      >
+        clinic address
+      </div>
+      <div
+        class="clinic-phone"
+      >
+        clinic phone
+      </div>
     </div>
   </div>
 </div>

--- a/app/tests/components/__snapshots__/ClinicSelectionList.test.tsx.snap
+++ b/app/tests/components/__snapshots__/ClinicSelectionList.test.tsx.snap
@@ -1,56 +1,54 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should match snapshot if the list is empty 1`] = `null`;
+exports[`should match snapshot if the list is empty 1`] = `<div />`;
 
 exports[`should match snapshot if the list is expanded 1`] = `
-[
+<div>
   <h2>
     Choose a clinic from the following list:
     <abbr
-      className="usa-hint usa-hint--required"
+      class="usa-hint usa-hint--required"
     >
        *
     </abbr>
-  </h2>,
+  </h2>
   <form
-    className="usa-form usa-form--large"
+    class="usa-form usa-form--large"
   >
     <fieldset
-      className="usa-fieldset"
+      class="usa-fieldset"
     >
       <div
-        className="usa-radio"
+        class="usa-radio"
       >
         <input
-          checked={false}
-          className="usa-radio__input usa-radio__input--tile"
+          class="usa-radio__input usa-radio__input--tile"
           id="CLINIC ZERO"
-          onChange={[MockFunction]}
           type="radio"
           value="CLINIC ZERO"
         />
         <label
-          className="usa-radio__label"
-          htmlFor="CLINIC ZERO"
+          class="usa-radio__label"
+          for="CLINIC ZERO"
         >
           <div
-            className="clinic-info"
+            class="clinic-info"
           >
             <div
-              className="clinic-name"
+              class="clinic-name"
             >
               CLINIC ZERO
             </div>
             <div
-              className="usa-checkbox__label-description"
+              class="usa-checkbox__label-description"
             >
               <div
-                className="clinic-street-address"
+                class="clinic-street-address"
               >
                 0000 St, Helena, MT 00000
               </div>
               <div
-                className="clinic-phone"
+                class="clinic-phone"
               >
                 (000) 000-0000
               </div>
@@ -59,38 +57,36 @@ exports[`should match snapshot if the list is expanded 1`] = `
         </label>
       </div>
       <div
-        className="usa-radio"
+        class="usa-radio"
       >
         <input
-          checked={false}
-          className="usa-radio__input usa-radio__input--tile"
+          class="usa-radio__input usa-radio__input--tile"
           id="CLINIC ONE"
-          onChange={[MockFunction]}
           type="radio"
           value="CLINIC ONE"
         />
         <label
-          className="usa-radio__label"
-          htmlFor="CLINIC ONE"
+          class="usa-radio__label"
+          for="CLINIC ONE"
         >
           <div
-            className="clinic-info"
+            class="clinic-info"
           >
             <div
-              className="clinic-name"
+              class="clinic-name"
             >
               CLINIC ONE
             </div>
             <div
-              className="usa-checkbox__label-description"
+              class="usa-checkbox__label-description"
             >
               <div
-                className="clinic-street-address"
+                class="clinic-street-address"
               >
                 1111 St, Helena, MT 11111
               </div>
               <div
-                className="clinic-phone"
+                class="clinic-phone"
               >
                 (111) 111-1111
               </div>
@@ -99,38 +95,36 @@ exports[`should match snapshot if the list is expanded 1`] = `
         </label>
       </div>
       <div
-        className="usa-radio"
+        class="usa-radio"
       >
         <input
-          checked={false}
-          className="usa-radio__input usa-radio__input--tile"
+          class="usa-radio__input usa-radio__input--tile"
           id="CLINIC TWO"
-          onChange={[MockFunction]}
           type="radio"
           value="CLINIC TWO"
         />
         <label
-          className="usa-radio__label"
-          htmlFor="CLINIC TWO"
+          class="usa-radio__label"
+          for="CLINIC TWO"
         >
           <div
-            className="clinic-info"
+            class="clinic-info"
           >
             <div
-              className="clinic-name"
+              class="clinic-name"
             >
               CLINIC TWO
             </div>
             <div
-              className="usa-checkbox__label-description"
+              class="usa-checkbox__label-description"
             >
               <div
-                className="clinic-street-address"
+                class="clinic-street-address"
               >
                 2222 St, Helena, MT 22222
               </div>
               <div
-                className="clinic-phone"
+                class="clinic-phone"
               >
                 (222) 222-2222
               </div>
@@ -139,38 +133,36 @@ exports[`should match snapshot if the list is expanded 1`] = `
         </label>
       </div>
       <div
-        className="usa-radio"
+        class="usa-radio"
       >
         <input
-          checked={false}
-          className="usa-radio__input usa-radio__input--tile"
+          class="usa-radio__input usa-radio__input--tile"
           id="CLINIC THREE"
-          onChange={[MockFunction]}
           type="radio"
           value="CLINIC THREE"
         />
         <label
-          className="usa-radio__label"
-          htmlFor="CLINIC THREE"
+          class="usa-radio__label"
+          for="CLINIC THREE"
         >
           <div
-            className="clinic-info"
+            class="clinic-info"
           >
             <div
-              className="clinic-name"
+              class="clinic-name"
             >
               CLINIC THREE
             </div>
             <div
-              className="usa-checkbox__label-description"
+              class="usa-checkbox__label-description"
             >
               <div
-                className="clinic-street-address"
+                class="clinic-street-address"
               >
                 3333 St, Helena, MT 33333
               </div>
               <div
-                className="clinic-phone"
+                class="clinic-phone"
               >
                 (333) 333-3333
               </div>
@@ -179,38 +171,36 @@ exports[`should match snapshot if the list is expanded 1`] = `
         </label>
       </div>
       <div
-        className="usa-radio"
+        class="usa-radio"
       >
         <input
-          checked={false}
-          className="usa-radio__input usa-radio__input--tile"
+          class="usa-radio__input usa-radio__input--tile"
           id="CLINIC FOUR"
-          onChange={[MockFunction]}
           type="radio"
           value="CLINIC FOUR"
         />
         <label
-          className="usa-radio__label"
-          htmlFor="CLINIC FOUR"
+          class="usa-radio__label"
+          for="CLINIC FOUR"
         >
           <div
-            className="clinic-info"
+            class="clinic-info"
           >
             <div
-              className="clinic-name"
+              class="clinic-name"
             >
               CLINIC FOUR
             </div>
             <div
-              className="usa-checkbox__label-description"
+              class="usa-checkbox__label-description"
             >
               <div
-                className="clinic-street-address"
+                class="clinic-street-address"
               >
                 4444 St, Helena, MT 44444
               </div>
               <div
-                className="clinic-phone"
+                class="clinic-phone"
               >
                 (444) 444-4444
               </div>
@@ -219,38 +209,36 @@ exports[`should match snapshot if the list is expanded 1`] = `
         </label>
       </div>
       <div
-        className="usa-radio"
+        class="usa-radio"
       >
         <input
-          checked={false}
-          className="usa-radio__input usa-radio__input--tile"
+          class="usa-radio__input usa-radio__input--tile"
           id="CLINIC FIVE"
-          onChange={[MockFunction]}
           type="radio"
           value="CLINIC FIVE"
         />
         <label
-          className="usa-radio__label"
-          htmlFor="CLINIC FIVE"
+          class="usa-radio__label"
+          for="CLINIC FIVE"
         >
           <div
-            className="clinic-info"
+            class="clinic-info"
           >
             <div
-              className="clinic-name"
+              class="clinic-name"
             >
               CLINIC FIVE
             </div>
             <div
-              className="usa-checkbox__label-description"
+              class="usa-checkbox__label-description"
             >
               <div
-                className="clinic-street-address"
+                class="clinic-street-address"
               >
                 5555 St, Helena, MT 55555
               </div>
               <div
-                className="clinic-phone"
+                class="clinic-phone"
               >
                 (555) 555-5555
               </div>
@@ -259,38 +247,36 @@ exports[`should match snapshot if the list is expanded 1`] = `
         </label>
       </div>
       <div
-        className="usa-radio"
+        class="usa-radio"
       >
         <input
-          checked={false}
-          className="usa-radio__input usa-radio__input--tile"
+          class="usa-radio__input usa-radio__input--tile"
           id="CLINIC SIX"
-          onChange={[MockFunction]}
           type="radio"
           value="CLINIC SIX"
         />
         <label
-          className="usa-radio__label"
-          htmlFor="CLINIC SIX"
+          class="usa-radio__label"
+          for="CLINIC SIX"
         >
           <div
-            className="clinic-info"
+            class="clinic-info"
           >
             <div
-              className="clinic-name"
+              class="clinic-name"
             >
               CLINIC SIX
             </div>
             <div
-              className="usa-checkbox__label-description"
+              class="usa-checkbox__label-description"
             >
               <div
-                className="clinic-street-address"
+                class="clinic-street-address"
               >
                 6666 St, Helena, MT 66666
               </div>
               <div
-                className="clinic-phone"
+                class="clinic-phone"
               >
                 (666) 666-6666
               </div>
@@ -299,38 +285,36 @@ exports[`should match snapshot if the list is expanded 1`] = `
         </label>
       </div>
       <div
-        className="usa-radio"
+        class="usa-radio"
       >
         <input
-          checked={false}
-          className="usa-radio__input usa-radio__input--tile"
+          class="usa-radio__input usa-radio__input--tile"
           id="CLINIC SEVEN"
-          onChange={[MockFunction]}
           type="radio"
           value="CLINIC SEVEN"
         />
         <label
-          className="usa-radio__label"
-          htmlFor="CLINIC SEVEN"
+          class="usa-radio__label"
+          for="CLINIC SEVEN"
         >
           <div
-            className="clinic-info"
+            class="clinic-info"
           >
             <div
-              className="clinic-name"
+              class="clinic-name"
             >
               CLINIC SEVEN
             </div>
             <div
-              className="usa-checkbox__label-description"
+              class="usa-checkbox__label-description"
             >
               <div
-                className="clinic-street-address"
+                class="clinic-street-address"
               >
                 7777 St, Helena, MT 77777
               </div>
               <div
-                className="clinic-phone"
+                class="clinic-phone"
               >
                 (777) 777-7777
               </div>
@@ -339,38 +323,37 @@ exports[`should match snapshot if the list is expanded 1`] = `
         </label>
       </div>
       <div
-        className="usa-radio"
+        class="usa-radio"
       >
         <input
-          checked={true}
-          className="usa-radio__input usa-radio__input--tile"
+          checked=""
+          class="usa-radio__input usa-radio__input--tile"
           id="CLINIC EIGHT"
-          onChange={[MockFunction]}
           type="radio"
           value="CLINIC EIGHT"
         />
         <label
-          className="usa-radio__label"
-          htmlFor="CLINIC EIGHT"
+          class="usa-radio__label"
+          for="CLINIC EIGHT"
         >
           <div
-            className="clinic-info"
+            class="clinic-info"
           >
             <div
-              className="clinic-name"
+              class="clinic-name"
             >
               CLINIC EIGHT
             </div>
             <div
-              className="usa-checkbox__label-description"
+              class="usa-checkbox__label-description"
             >
               <div
-                className="clinic-street-address"
+                class="clinic-street-address"
               >
                 8888 St, Helena, MT 88888
               </div>
               <div
-                className="clinic-phone"
+                class="clinic-phone"
               >
                 (888) 888-8888
               </div>
@@ -380,65 +363,61 @@ exports[`should match snapshot if the list is expanded 1`] = `
       </div>
     </fieldset>
     <button
-      className="usa-button usa-button--small display-block margin-top-6"
-      disabled={false}
-      onClick={[Function]}
+      class="usa-button usa-button--small display-block margin-top-6"
     >
       Continue
     </button>
-  </form>,
-]
+  </form>
+</div>
 `;
 
 exports[`should match snapshot if the list is not expanded 1`] = `
-[
+<div>
   <h2>
     Choose a clinic from the following list:
     <abbr
-      className="usa-hint usa-hint--required"
+      class="usa-hint usa-hint--required"
     >
        *
     </abbr>
-  </h2>,
+  </h2>
   <form
-    className="usa-form usa-form--large"
+    class="usa-form usa-form--large"
   >
     <fieldset
-      className="usa-fieldset"
+      class="usa-fieldset"
     >
       <div
-        className="usa-radio"
+        class="usa-radio"
       >
         <input
-          checked={false}
-          className="usa-radio__input usa-radio__input--tile"
+          class="usa-radio__input usa-radio__input--tile"
           id="CLINIC ZERO"
-          onChange={[MockFunction]}
           type="radio"
           value="CLINIC ZERO"
         />
         <label
-          className="usa-radio__label"
-          htmlFor="CLINIC ZERO"
+          class="usa-radio__label"
+          for="CLINIC ZERO"
         >
           <div
-            className="clinic-info"
+            class="clinic-info"
           >
             <div
-              className="clinic-name"
+              class="clinic-name"
             >
               CLINIC ZERO
             </div>
             <div
-              className="usa-checkbox__label-description"
+              class="usa-checkbox__label-description"
             >
               <div
-                className="clinic-street-address"
+                class="clinic-street-address"
               >
                 0000 St, Helena, MT 00000
               </div>
               <div
-                className="clinic-phone"
+                class="clinic-phone"
               >
                 (000) 000-0000
               </div>
@@ -447,38 +426,36 @@ exports[`should match snapshot if the list is not expanded 1`] = `
         </label>
       </div>
       <div
-        className="usa-radio"
+        class="usa-radio"
       >
         <input
-          checked={false}
-          className="usa-radio__input usa-radio__input--tile"
+          class="usa-radio__input usa-radio__input--tile"
           id="CLINIC ONE"
-          onChange={[MockFunction]}
           type="radio"
           value="CLINIC ONE"
         />
         <label
-          className="usa-radio__label"
-          htmlFor="CLINIC ONE"
+          class="usa-radio__label"
+          for="CLINIC ONE"
         >
           <div
-            className="clinic-info"
+            class="clinic-info"
           >
             <div
-              className="clinic-name"
+              class="clinic-name"
             >
               CLINIC ONE
             </div>
             <div
-              className="usa-checkbox__label-description"
+              class="usa-checkbox__label-description"
             >
               <div
-                className="clinic-street-address"
+                class="clinic-street-address"
               >
                 1111 St, Helena, MT 11111
               </div>
               <div
-                className="clinic-phone"
+                class="clinic-phone"
               >
                 (111) 111-1111
               </div>
@@ -487,38 +464,36 @@ exports[`should match snapshot if the list is not expanded 1`] = `
         </label>
       </div>
       <div
-        className="usa-radio"
+        class="usa-radio"
       >
         <input
-          checked={false}
-          className="usa-radio__input usa-radio__input--tile"
+          class="usa-radio__input usa-radio__input--tile"
           id="CLINIC TWO"
-          onChange={[MockFunction]}
           type="radio"
           value="CLINIC TWO"
         />
         <label
-          className="usa-radio__label"
-          htmlFor="CLINIC TWO"
+          class="usa-radio__label"
+          for="CLINIC TWO"
         >
           <div
-            className="clinic-info"
+            class="clinic-info"
           >
             <div
-              className="clinic-name"
+              class="clinic-name"
             >
               CLINIC TWO
             </div>
             <div
-              className="usa-checkbox__label-description"
+              class="usa-checkbox__label-description"
             >
               <div
-                className="clinic-street-address"
+                class="clinic-street-address"
               >
                 2222 St, Helena, MT 22222
               </div>
               <div
-                className="clinic-phone"
+                class="clinic-phone"
               >
                 (222) 222-2222
               </div>
@@ -527,38 +502,36 @@ exports[`should match snapshot if the list is not expanded 1`] = `
         </label>
       </div>
       <div
-        className="usa-radio"
+        class="usa-radio"
       >
         <input
-          checked={false}
-          className="usa-radio__input usa-radio__input--tile"
+          class="usa-radio__input usa-radio__input--tile"
           id="CLINIC THREE"
-          onChange={[MockFunction]}
           type="radio"
           value="CLINIC THREE"
         />
         <label
-          className="usa-radio__label"
-          htmlFor="CLINIC THREE"
+          class="usa-radio__label"
+          for="CLINIC THREE"
         >
           <div
-            className="clinic-info"
+            class="clinic-info"
           >
             <div
-              className="clinic-name"
+              class="clinic-name"
             >
               CLINIC THREE
             </div>
             <div
-              className="usa-checkbox__label-description"
+              class="usa-checkbox__label-description"
             >
               <div
-                className="clinic-street-address"
+                class="clinic-street-address"
               >
                 3333 St, Helena, MT 33333
               </div>
               <div
-                className="clinic-phone"
+                class="clinic-phone"
               >
                 (333) 333-3333
               </div>
@@ -567,19 +540,16 @@ exports[`should match snapshot if the list is not expanded 1`] = `
         </label>
       </div>
       <button
-        className="usa-button usa-button--small display-block usa-button--unstyled margin-top-1"
-        onClick={[Function]}
+        class="usa-button usa-button--small display-block usa-button--unstyled margin-top-1"
       >
         Show more clinic options
       </button>
     </fieldset>
     <button
-      className="usa-button usa-button--small display-block margin-top-6"
-      disabled={false}
-      onClick={[Function]}
+      class="usa-button usa-button--small display-block margin-top-6"
     >
       Continue
     </button>
-  </form>,
-]
+  </form>
+</div>
 `;

--- a/app/tests/components/__snapshots__/Dropdown.test.tsx.snap
+++ b/app/tests/components/__snapshots__/Dropdown.test.tsx.snap
@@ -1,18 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should match snapshot 1`] = `
-[
+<div>
   <label
-    className="usa-label"
-    htmlFor="test-id"
+    class="usa-label"
+    for="test-id"
   >
     dropdown label
-  </label>,
+  </label>
   <select
-    className="usa-select"
+    class="usa-select"
     id="test-id"
     name="test-id"
-    onChange={[Function]}
   >
     <option
       value=""
@@ -36,6 +35,6 @@ exports[`should match snapshot 1`] = `
     >
       c
     </option>
-  </select>,
-]
+  </select>
+</div>
 `;

--- a/app/tests/components/__snapshots__/IncomeRow.test.tsx.snap
+++ b/app/tests/components/__snapshots__/IncomeRow.test.tsx.snap
@@ -1,29 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should match snapshot when householdSize is an empty string 1`] = `
-<tr>
-  <td>
-    $XX,XXX
-  </td>
-  <td>
-    $XX,XXX
-  </td>
-  <td>
-    $XX,XXX
-  </td>
-</tr>
+<div>
+  <tr>
+    <td>
+      $XX,XXX
+    </td>
+    <td>
+      $XX,XXX
+    </td>
+    <td>
+      $XX,XXX
+    </td>
+  </tr>
+</div>
 `;
 
 exports[`should match snapshot when householdSize is not empty string 1`] = `
-<tr>
-  <td>
-    $100
-  </td>
-  <td>
-    $200
-  </td>
-  <td>
-    $300
-  </td>
-</tr>
+<div>
+  <tr>
+    <td>
+      $100
+    </td>
+    <td>
+      $200
+    </td>
+    <td>
+      $300
+    </td>
+  </tr>
+</div>
 `;

--- a/app/tests/components/__snapshots__/InputChoiceGroup.test.tsx.snap
+++ b/app/tests/components/__snapshots__/InputChoiceGroup.test.tsx.snap
@@ -1,135 +1,127 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should match snapshot when it is a set of checkboxes 1`] = `
-<fieldset
-  className="usa-fieldset"
->
-  <h2>
-    title
-  </h2>
-  <div
-    className="usa-checkbox"
+<div>
+  <fieldset
+    class="usa-fieldset"
   >
-    <input
-      checked={false}
-      className="usa-checkbox__input usa-checkbox__input--tile"
-      id="name-a-a"
-      name="name-a"
-      onChange={[Function]}
-      type="checkbox"
-      value="a"
-    />
-    <label
-      className="usa-checkbox__label"
-      htmlFor="name-a-a"
+    <h2>
+      title
+    </h2>
+    <div
+      class="usa-checkbox"
     >
-      label a
-    </label>
-  </div>
-  <div
-    className="usa-checkbox"
-  >
-    <input
-      checked={false}
-      className="usa-checkbox__input usa-checkbox__input--tile"
-      id="name-b-b"
-      name="name-b"
-      onChange={[Function]}
-      type="checkbox"
-      value="b"
-    />
-    <label
-      className="usa-checkbox__label"
-      htmlFor="name-b-b"
+      <input
+        class="usa-checkbox__input usa-checkbox__input--tile"
+        id="name-a-a"
+        name="name-a"
+        type="checkbox"
+        value="a"
+      />
+      <label
+        class="usa-checkbox__label"
+        for="name-a-a"
+      >
+        label a
+      </label>
+    </div>
+    <div
+      class="usa-checkbox"
     >
-      label b
-    </label>
-  </div>
-  <div
-    className="usa-checkbox"
-  >
-    <input
-      checked={false}
-      className="usa-checkbox__input usa-checkbox__input--tile"
-      id="name-c-c"
-      name="name-c"
-      onChange={[Function]}
-      type="checkbox"
-      value="c"
-    />
-    <label
-      className="usa-checkbox__label"
-      htmlFor="name-c-c"
+      <input
+        class="usa-checkbox__input usa-checkbox__input--tile"
+        id="name-b-b"
+        name="name-b"
+        type="checkbox"
+        value="b"
+      />
+      <label
+        class="usa-checkbox__label"
+        for="name-b-b"
+      >
+        label b
+      </label>
+    </div>
+    <div
+      class="usa-checkbox"
     >
-      label c
-    </label>
-  </div>
-</fieldset>
+      <input
+        class="usa-checkbox__input usa-checkbox__input--tile"
+        id="name-c-c"
+        name="name-c"
+        type="checkbox"
+        value="c"
+      />
+      <label
+        class="usa-checkbox__label"
+        for="name-c-c"
+      >
+        label c
+      </label>
+    </div>
+  </fieldset>
+</div>
 `;
 
 exports[`should match snapshot when it is a set of radio buttons 1`] = `
-<fieldset
-  className="usa-fieldset"
->
-  <h2>
-    title
-  </h2>
-  <div
-    className="usa-radio"
+<div>
+  <fieldset
+    class="usa-fieldset"
   >
-    <input
-      checked={false}
-      className="usa-radio__input usa-radio__input--tile"
-      id="name-a-a"
-      name="name-a"
-      onChange={[Function]}
-      type="radio"
-      value="a"
-    />
-    <label
-      className="usa-radio__label"
-      htmlFor="name-a-a"
+    <h2>
+      title
+    </h2>
+    <div
+      class="usa-radio"
     >
-      label a
-    </label>
-  </div>
-  <div
-    className="usa-radio"
-  >
-    <input
-      checked={false}
-      className="usa-radio__input usa-radio__input--tile"
-      id="name-b-b"
-      name="name-b"
-      onChange={[Function]}
-      type="radio"
-      value="b"
-    />
-    <label
-      className="usa-radio__label"
-      htmlFor="name-b-b"
+      <input
+        class="usa-radio__input usa-radio__input--tile"
+        id="name-a-a"
+        name="name-a"
+        type="radio"
+        value="a"
+      />
+      <label
+        class="usa-radio__label"
+        for="name-a-a"
+      >
+        label a
+      </label>
+    </div>
+    <div
+      class="usa-radio"
     >
-      label b
-    </label>
-  </div>
-  <div
-    className="usa-radio"
-  >
-    <input
-      checked={false}
-      className="usa-radio__input usa-radio__input--tile"
-      id="name-c-c"
-      name="name-c"
-      onChange={[Function]}
-      type="radio"
-      value="c"
-    />
-    <label
-      className="usa-radio__label"
-      htmlFor="name-c-c"
+      <input
+        class="usa-radio__input usa-radio__input--tile"
+        id="name-b-b"
+        name="name-b"
+        type="radio"
+        value="b"
+      />
+      <label
+        class="usa-radio__label"
+        for="name-b-b"
+      >
+        label b
+      </label>
+    </div>
+    <div
+      class="usa-radio"
     >
-      label c
-    </label>
-  </div>
-</fieldset>
+      <input
+        class="usa-radio__input usa-radio__input--tile"
+        id="name-c-c"
+        name="name-c"
+        type="radio"
+        value="c"
+      />
+      <label
+        class="usa-radio__label"
+        for="name-c-c"
+      >
+        label c
+      </label>
+    </div>
+  </fieldset>
+</div>
 `;

--- a/app/tests/components/__snapshots__/Layout.test.tsx.snap
+++ b/app/tests/components/__snapshots__/Layout.test.tsx.snap
@@ -1,337 +1,151 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should match snapshot 1`] = `
-<div
-  className="container"
->
-  <header
-    className="header usa-header usa-header--basic"
-    role="banner"
+<div>
+  <div
+    class="container"
   >
-    <div
-      className="usa-navbar"
+    <header
+      class="header usa-header usa-header--basic"
+      role="banner"
     >
       <div
-        className="grid-row"
+        class="usa-navbar"
       >
         <div
-          className="desktop:grid-col-8"
+          class="grid-row"
         >
           <div
-            className="usa-logo margin-left-2"
+            class="desktop:grid-col-8"
           >
-            <em
-              className="usa-logo__text"
+            <div
+              class="usa-logo margin-left-2"
             >
-              Apply for WIC in Montana
-            </em>
+              <em
+                class="usa-logo__text"
+              >
+                Apply for WIC in Montana
+              </em>
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  </header>
-  <main
-    className="main"
-  >
-    <div
-      className="grid-row"
+    </header>
+    <main
+      class="main"
     >
       <div
-        className="desktop:grid-col-8 padding-2 padding-bottom-8"
-      >
-        <h1>
-          'child'
-        </h1>
-      </div>
-    </div>
-  </main>
-  <footer
-    className="footer usa-footer usa-footer--slim"
-  >
-    <div
-      className="usa-footer__primary-section"
-    >
-      <div
-        className="grid-row"
+        class="grid-row"
       >
         <div
-          className="desktop:grid-col-8 padding-2"
+          class="desktop:grid-col-8 padding-2 padding-bottom-8"
+        >
+          <h1>
+            'child'
+          </h1>
+        </div>
+      </div>
+    </main>
+    <footer
+      class="footer usa-footer usa-footer--slim"
+    >
+      <div
+        class="usa-footer__primary-section"
+      >
+        <div
+          class="grid-row"
         >
           <div
-            className="logos"
+            class="desktop:grid-col-8 padding-2"
           >
-            <span
-              style={
-                {
-                  "background": "none",
-                  "border": 0,
-                  "boxSizing": "border-box",
-                  "display": "inline-block",
-                  "height": "initial",
-                  "margin": 0,
-                  "maxWidth": "100%",
-                  "opacity": 1,
-                  "overflow": "hidden",
-                  "padding": 0,
-                  "position": "relative",
-                  "width": "initial",
-                }
-              }
+            <div
+              class="logos"
             >
               <span
-                style={
-                  {
-                    "background": "none",
-                    "border": 0,
-                    "boxSizing": "border-box",
-                    "display": "block",
-                    "height": "initial",
-                    "margin": 0,
-                    "maxWidth": "100%",
-                    "opacity": 1,
-                    "padding": 0,
-                    "width": "initial",
-                  }
-                }
+                style="box-sizing: border-box; display: inline-block; overflow: hidden; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; position: relative; max-width: 100%;"
               >
-                <img
-                  alt=""
-                  aria-hidden={true}
-                  src="data:image/svg+xml,%3csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20version=%271.1%27%20width=%2764.52%27%20height=%2732%27/%3e"
-                  style={
-                    {
-                      "background": "none",
-                      "border": 0,
-                      "display": "block",
-                      "height": "initial",
-                      "margin": 0,
-                      "maxWidth": "100%",
-                      "opacity": 1,
-                      "padding": 0,
-                      "width": "initial",
-                    }
-                  }
-                />
-              </span>
-              <img
-                alt="WIC logo"
-                data-nimg="intrinsic"
-                decoding="async"
-                onError={[Function]}
-                onLoad={[Function]}
-                src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-                style={
-                  {
-                    "border": "none",
-                    "bottom": 0,
-                    "boxSizing": "border-box",
-                    "display": "block",
-                    "height": 0,
-                    "left": 0,
-                    "margin": "auto",
-                    "maxHeight": "100%",
-                    "maxWidth": "100%",
-                    "minHeight": "100%",
-                    "minWidth": "100%",
-                    "objectFit": undefined,
-                    "objectPosition": undefined,
-                    "padding": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                    "width": 0,
-                  }
-                }
-              />
-              <noscript>
+                <span
+                  style="box-sizing: border-box; display: block; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; max-width: 100%;"
+                >
+                  <img
+                    alt=""
+                    aria-hidden="true"
+                    src="data:image/svg+xml,%3csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20version=%271.1%27%20width=%2764.52%27%20height=%2732%27/%3e"
+                    style="display: block; max-width: 100%; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px;"
+                  />
+                </span>
                 <img
                   alt="WIC logo"
                   data-nimg="intrinsic"
                   decoding="async"
-                  loading="lazy"
-                  src="/img/wic-logo.svg"
-                  srcSet="/img/wic-logo.svg 1x, /img/wic-logo.svg 2x"
-                  style={
-                    {
-                      "border": "none",
-                      "bottom": 0,
-                      "boxSizing": "border-box",
-                      "display": "block",
-                      "height": 0,
-                      "left": 0,
-                      "margin": "auto",
-                      "maxHeight": "100%",
-                      "maxWidth": "100%",
-                      "minHeight": "100%",
-                      "minWidth": "100%",
-                      "objectFit": undefined,
-                      "objectPosition": undefined,
-                      "padding": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                      "width": 0,
-                    }
-                  }
+                  src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+                  style="position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
                 />
-              </noscript>
-            </span>
-            <span
-              style={
-                {
-                  "background": "none",
-                  "border": 0,
-                  "boxSizing": "border-box",
-                  "display": "inline-block",
-                  "height": "initial",
-                  "margin": 0,
-                  "maxWidth": "100%",
-                  "opacity": 1,
-                  "overflow": "hidden",
-                  "padding": 0,
-                  "position": "relative",
-                  "width": "initial",
-                }
-              }
-            >
-              <span
-                style={
-                  {
-                    "background": "none",
-                    "border": 0,
-                    "boxSizing": "border-box",
-                    "display": "block",
-                    "height": "initial",
-                    "margin": 0,
-                    "maxWidth": "100%",
-                    "opacity": 1,
-                    "padding": 0,
-                    "width": "initial",
-                  }
-                }
-              >
-                <img
-                  alt=""
-                  aria-hidden={true}
-                  src="data:image/svg+xml,%3csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20version=%271.1%27%20width=%2746.22%27%20height=%2732%27/%3e"
-                  style={
-                    {
-                      "background": "none",
-                      "border": 0,
-                      "display": "block",
-                      "height": "initial",
-                      "margin": 0,
-                      "maxWidth": "100%",
-                      "opacity": 1,
-                      "padding": 0,
-                      "width": "initial",
-                    }
-                  }
-                />
+                <noscript />
               </span>
-              <img
-                alt="Monthana DPHHS logo"
-                data-nimg="intrinsic"
-                decoding="async"
-                onError={[Function]}
-                onLoad={[Function]}
-                src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-                style={
-                  {
-                    "border": "none",
-                    "bottom": 0,
-                    "boxSizing": "border-box",
-                    "display": "block",
-                    "height": 0,
-                    "left": 0,
-                    "margin": "auto",
-                    "maxHeight": "100%",
-                    "maxWidth": "100%",
-                    "minHeight": "100%",
-                    "minWidth": "100%",
-                    "objectFit": undefined,
-                    "objectPosition": undefined,
-                    "padding": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                    "width": 0,
-                  }
-                }
-              />
-              <noscript>
+              <span
+                style="box-sizing: border-box; display: inline-block; overflow: hidden; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; position: relative; max-width: 100%;"
+              >
+                <span
+                  style="box-sizing: border-box; display: block; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; max-width: 100%;"
+                >
+                  <img
+                    alt=""
+                    aria-hidden="true"
+                    src="data:image/svg+xml,%3csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20version=%271.1%27%20width=%2746.22%27%20height=%2732%27/%3e"
+                    style="display: block; max-width: 100%; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px;"
+                  />
+                </span>
                 <img
                   alt="Monthana DPHHS logo"
                   data-nimg="intrinsic"
                   decoding="async"
-                  loading="lazy"
-                  src="/img/montana-logo.svg"
-                  srcSet="/img/montana-logo.svg 1x, /img/montana-logo.svg 2x"
-                  style={
-                    {
-                      "border": "none",
-                      "bottom": 0,
-                      "boxSizing": "border-box",
-                      "display": "block",
-                      "height": 0,
-                      "left": 0,
-                      "margin": "auto",
-                      "maxHeight": "100%",
-                      "maxWidth": "100%",
-                      "minHeight": "100%",
-                      "minWidth": "100%",
-                      "objectFit": undefined,
-                      "objectPosition": undefined,
-                      "padding": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                      "width": 0,
-                    }
-                  }
+                  src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+                  style="position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
                 />
-              </noscript>
-            </span>
-          </div>
-          <div
-            className="font-body-3xs"
-          >
-            <p>
-              This site is a demonstration project built with 
-              <a
-                className="usa-link usa-link--external"
-                href="https://dphhs.mt.gov/ecfsd/wic/index"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                Montana WIC
-              </a>
-               and is for example purposes only. If you need to submit an application for WIC, please use 
-              <a
-                className="usa-link usa-link--external"
-                href="https://www.signupwic.com/"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                SignUpWIC.com
-              </a>
-               to find a location near you.
-            </p>
-            <p>
-              This institution is an equal opportunity provider. 
-              <a
-                className="usa-link usa-link--external"
-                href="https://www.fns.usda.gov/civil-rights/usda-nondiscrimination-statement-other-fns-programs"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                USDA Non-Discrimination Statement
-              </a>
-            </p>
+                <noscript />
+              </span>
+            </div>
+            <div
+              class="font-body-3xs"
+            >
+              <p>
+                This site is a demonstration project built with 
+                <a
+                  class="usa-link usa-link--external"
+                  href="https://dphhs.mt.gov/ecfsd/wic/index"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Montana WIC
+                </a>
+                 and is for example purposes only. If you need to submit an application for WIC, please use 
+                <a
+                  class="usa-link usa-link--external"
+                  href="https://www.signupwic.com/"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  SignUpWIC.com
+                </a>
+                 to find a location near you.
+              </p>
+              <p>
+                This institution is an equal opportunity provider. 
+                <a
+                  class="usa-link usa-link--external"
+                  href="https://www.fns.usda.gov/civil-rights/usda-nondiscrimination-statement-other-fns-programs"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  USDA Non-Discrimination Statement
+                </a>
+              </p>
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  </footer>
+    </footer>
+  </div>
 </div>
 `;

--- a/app/tests/components/__snapshots__/List.test.tsx.snap
+++ b/app/tests/components/__snapshots__/List.test.tsx.snap
@@ -1,15 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should match snapshot 1`] = `
-<ul>
-  <li>
-    list item a
-  </li>
-  <li>
-    list item b
-  </li>
-  <li>
-    list item c
-  </li>
-</ul>
+<div>
+  <ul>
+    <li>
+      list item a
+    </li>
+    <li>
+      list item b
+    </li>
+    <li>
+      list item c
+    </li>
+  </ul>
+</div>
 `;

--- a/app/tests/components/__snapshots__/PageError.test.tsx.snap
+++ b/app/tests/components/__snapshots__/PageError.test.tsx.snap
@@ -1,21 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should match snapshot 1`] = `
-<div
-  className="margin-bottom-3"
->
+<div>
   <div
-    className="usa-alert usa-alert--error "
-    role="alert"
+    class="margin-bottom-3"
   >
     <div
-      className="usa-alert__body"
+      class="usa-alert usa-alert--error "
+      role="alert"
     >
-      <p
-        className="usa-alert__text"
+      <div
+        class="usa-alert__body"
       >
-        alert body text
-      </p>
+        <p
+          class="usa-alert__text"
+        >
+          alert body text
+        </p>
+      </div>
     </div>
   </div>
 </div>

--- a/app/tests/components/__snapshots__/Required.test.tsx.snap
+++ b/app/tests/components/__snapshots__/Required.test.tsx.snap
@@ -1,9 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should match snapshot 1`] = `
-<abbr
-  className="usa-hint usa-hint--required"
->
-   *
-</abbr>
+<div>
+  <abbr
+    class="usa-hint usa-hint--required"
+  >
+     *
+  </abbr>
+</div>
 `;

--- a/app/tests/components/__snapshots__/RequiredQuestionStatement.test.tsx.snap
+++ b/app/tests/components/__snapshots__/RequiredQuestionStatement.test.tsx.snap
@@ -1,14 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should match snapshot 1`] = `
-<p>
-  All required questions are marked with an asterisk
-   (
-  <abbr
-    className="usa-hint usa-hint--required"
-  >
-    *
-  </abbr>
-  ).
-</p>
+<div>
+  <p>
+    All required questions are marked with an asterisk
+     (
+    <abbr
+      class="usa-hint usa-hint--required"
+    >
+      *
+    </abbr>
+    ).
+  </p>
+</div>
 `;

--- a/app/tests/components/__snapshots__/ReviewCollection.test.tsx.snap
+++ b/app/tests/components/__snapshots__/ReviewCollection.test.tsx.snap
@@ -1,85 +1,89 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should match snapshot when it is not the first element 1`] = `
-<div
-  className="review-collection margin-top-6 border-bottom-1px"
->
-  <h2>
-    header key
-  </h2>
-  <dl
-    className="margin-bottom-2"
+<div>
+  <div
+    class="review-collection margin-top-6 border-bottom-1px"
   >
-    <div
-      className="review-element margin-bottom-3"
+    <h2>
+      header key
+    </h2>
+    <dl
+      class="margin-bottom-2"
     >
-      <dt>
-        <strong>
-          element a
-        </strong>
-      </dt>
-      <dd
-        className="margin-left-0"
+      <div
+        class="review-element margin-bottom-3"
       >
-        child a
-      </dd>
-    </div>
-    <div
-      className="review-element margin-bottom-3"
-    >
-      <dt>
-        <strong>
-          element b
-        </strong>
-      </dt>
-      <dd
-        className="margin-left-0"
+        <dt>
+          <strong>
+            element a
+          </strong>
+        </dt>
+        <dd
+          class="margin-left-0"
+        >
+          child a
+        </dd>
+      </div>
+      <div
+        class="review-element margin-bottom-3"
       >
-        child b
-      </dd>
-    </div>
-  </dl>
+        <dt>
+          <strong>
+            element b
+          </strong>
+        </dt>
+        <dd
+          class="margin-left-0"
+        >
+          child b
+        </dd>
+      </div>
+    </dl>
+  </div>
 </div>
 `;
 
 exports[`should match snapshot when it is the first element 1`] = `
-<div
-  className="review-collection margin-top-3 border-bottom-1px"
->
-  <h2>
-    header key
-  </h2>
-  <dl
-    className="margin-bottom-2"
+<div>
+  <div
+    class="review-collection margin-top-3 border-bottom-1px"
   >
-    <div
-      className="review-element margin-bottom-3"
+    <h2>
+      header key
+    </h2>
+    <dl
+      class="margin-bottom-2"
     >
-      <dt>
-        <strong>
-          element a
-        </strong>
-      </dt>
-      <dd
-        className="margin-left-0"
+      <div
+        class="review-element margin-bottom-3"
       >
-        child a
-      </dd>
-    </div>
-    <div
-      className="review-element margin-bottom-3"
-    >
-      <dt>
-        <strong>
-          element b
-        </strong>
-      </dt>
-      <dd
-        className="margin-left-0"
+        <dt>
+          <strong>
+            element a
+          </strong>
+        </dt>
+        <dd
+          class="margin-left-0"
+        >
+          child a
+        </dd>
+      </div>
+      <div
+        class="review-element margin-bottom-3"
       >
-        child b
-      </dd>
-    </div>
-  </dl>
+        <dt>
+          <strong>
+            element b
+          </strong>
+        </dt>
+        <dd
+          class="margin-left-0"
+        >
+          child b
+        </dd>
+      </div>
+    </dl>
+  </div>
 </div>
 `;

--- a/app/tests/components/__snapshots__/ReviewElement.test.tsx.snap
+++ b/app/tests/components/__snapshots__/ReviewElement.test.tsx.snap
@@ -1,18 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should match snapshot 1`] = `
-<div
-  className="review-element margin-bottom-3"
->
-  <dt>
-    <strong>
-      label
-    </strong>
-  </dt>
-  <dd
-    className="margin-left-0"
+<div>
+  <div
+    class="review-element margin-bottom-3"
   >
-    This is a child
-  </dd>
+    <dt>
+      <strong>
+        label
+      </strong>
+    </dt>
+    <dd
+      class="margin-left-0"
+    >
+      This is a child
+    </dd>
+  </div>
 </div>
 `;

--- a/app/tests/components/__snapshots__/StyledLink.test.tsx.snap
+++ b/app/tests/components/__snapshots__/StyledLink.test.tsx.snap
@@ -1,24 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should match snapshot for external link 1`] = `
-<a
-  className="usa-link usa-link--external"
-  href="/somewhere"
-  rel="noopener noreferrer"
-  target="_blank"
->
-  link text
-</a>
+<div>
+  <a
+    class="usa-link usa-link--external"
+    href="/somewhere"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    link text
+  </a>
+</div>
 `;
 
 exports[`should match snapshot for internal link 1`] = `
-<a
-  className="usa-link"
-  href="/somewhere"
-  onClick={[Function]}
-  onMouseEnter={[Function]}
-  onTouchStart={[Function]}
->
-  link text
-</a>
+<div>
+  <a
+    class="usa-link"
+    href="/somewhere"
+  >
+    link text
+  </a>
+</div>
 `;

--- a/app/tests/components/__snapshots__/TextField.test.tsx.snap
+++ b/app/tests/components/__snapshots__/TextField.test.tsx.snap
@@ -1,39 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should match snapshot when it is a textarea 1`] = `
-[
+<div>
   <label
-    className="usa-label"
-    htmlFor="input-id"
+    class="usa-label"
+    for="input-id"
   >
     input label
-  </label>,
+  </label>
   <textarea
-    className="usa-textarea"
+    class="usa-textarea"
     id="input-id"
     name="input-id"
-    onChange={[Function]}
     role="textbox"
-    value=""
-  />,
-]
+  />
+</div>
 `;
 
 exports[`should match snapshot when it is a textfield 1`] = `
-[
+<div>
   <label
-    className="usa-label"
-    htmlFor="input-id"
+    class="usa-label"
+    for="input-id"
   >
     input label
-  </label>,
+  </label>
   <input
-    className="usa-input"
+    class="usa-input"
     id="input-id"
     name="input-id"
-    onChange={[Function]}
     role="textbox"
     value=""
-  />,
-]
+  />
+</div>
 `;

--- a/app/tests/helpers/sharedTests.ts
+++ b/app/tests/helpers/sharedTests.ts
@@ -3,14 +3,8 @@ import { axe } from 'jest-axe'
 import mockRouter from 'next-router-mock'
 import singletonRouter from 'next/router'
 import { ReactElement } from 'react'
-import renderer from 'react-test-renderer'
 
 import { UserEventReturn } from './setup'
-
-export function testSnapshot(element: ReactElement) {
-  const tree = renderer.create(element).toJSON()
-  expect(tree).toMatchSnapshot()
-}
 
 export async function testAccessibility(element: ReactElement) {
   const { container } = render(element)

--- a/app/tests/pages/__snapshots__/choose-clinic.test.tsx.snap
+++ b/app/tests/pages/__snapshots__/choose-clinic.test.tsx.snap
@@ -1,43 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should match full page snapshot 1`] = `
-[
+<div>
   <a
-    className="usa-link"
+    class="usa-link"
     href="/income"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onTouchStart={[Function]}
   >
     Back
-  </a>,
+  </a>
   <h1>
     Choose a clinic
-  </h1>,
+  </h1>
   <p>
     All required questions are marked with an asterisk
      (
     <abbr
-      className="usa-hint usa-hint--required"
+      class="usa-hint usa-hint--required"
     >
       *
     </abbr>
     ).
-  </p>,
+  </p>
   <div
-    className="content-group"
+    class="content-group"
   >
     <p>
       You’ll need to visit a clinic in person to complete a certification appointment for WIC. Choose the clinic you would like to go to during business hours.
     </p>
-  </div>,
+  </div>
   <div
-    className="content-group"
+    class="content-group"
   >
     <h2>
       Enter your residential ZIP code to search for a clinic:
       <abbr
-        className="usa-hint usa-hint--required"
+        class="usa-hint usa-hint--required"
       >
          *
       </abbr>
@@ -46,148 +43,51 @@ exports[`should match full page snapshot 1`] = `
       aria-label="Search clinic by zip"
     >
       <form
-        className="usa-search usa-search--small"
-        onSubmit={[Function]}
+        class="usa-search usa-search--small"
         role="search"
       >
         <label
-          className="usa-sr-only"
-          htmlFor="search-field-en-small"
+          class="usa-sr-only"
+          for="search-field-en-small"
         >
           Enter your residential ZIP code to search for a clinic:
         </label>
         <input
-          className="usa-input usa-input-error"
+          class="usa-input usa-input-error"
           id="search-field-en-small"
-          onChange={[Function]}
           type="search"
           value=""
         />
         <button
-          className="usa-button"
+          class="usa-button"
           type="submit"
         >
           <span
-            style={
-              {
-                "background": "none",
-                "border": 0,
-                "boxSizing": "border-box",
-                "display": "inline-block",
-                "height": "initial",
-                "margin": 0,
-                "maxWidth": "100%",
-                "opacity": 1,
-                "overflow": "hidden",
-                "padding": 0,
-                "position": "relative",
-                "width": "initial",
-              }
-            }
+            style="box-sizing: border-box; display: inline-block; overflow: hidden; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; position: relative; max-width: 100%;"
           >
             <span
-              style={
-                {
-                  "background": "none",
-                  "border": 0,
-                  "boxSizing": "border-box",
-                  "display": "block",
-                  "height": "initial",
-                  "margin": 0,
-                  "maxWidth": "100%",
-                  "opacity": 1,
-                  "padding": 0,
-                  "width": "initial",
-                }
-              }
+              style="box-sizing: border-box; display: block; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; max-width: 100%;"
             >
               <img
                 alt=""
-                aria-hidden={true}
+                aria-hidden="true"
                 src="data:image/svg+xml,%3csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20version=%271.1%27%20width=%2720%27%20height=%2720%27/%3e"
-                style={
-                  {
-                    "background": "none",
-                    "border": 0,
-                    "display": "block",
-                    "height": "initial",
-                    "margin": 0,
-                    "maxWidth": "100%",
-                    "opacity": 1,
-                    "padding": 0,
-                    "width": "initial",
-                  }
-                }
+                style="display: block; max-width: 100%; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px;"
               />
             </span>
             <img
               alt="Search"
-              className="usa-search__submit-icon"
+              class="usa-search__submit-icon"
               data-nimg="intrinsic"
               decoding="async"
-              onError={[Function]}
-              onLoad={[Function]}
               src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-              style={
-                {
-                  "border": "none",
-                  "bottom": 0,
-                  "boxSizing": "border-box",
-                  "display": "block",
-                  "height": 0,
-                  "left": 0,
-                  "margin": "auto",
-                  "maxHeight": "100%",
-                  "maxWidth": "100%",
-                  "minHeight": "100%",
-                  "minWidth": "100%",
-                  "objectFit": undefined,
-                  "objectPosition": undefined,
-                  "padding": 0,
-                  "position": "absolute",
-                  "right": 0,
-                  "top": 0,
-                  "width": 0,
-                }
-              }
+              style="position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
             />
-            <noscript>
-              <img
-                alt="Search"
-                className="usa-search__submit-icon"
-                data-nimg="intrinsic"
-                decoding="async"
-                loading="lazy"
-                src="/img/search.svg"
-                srcSet="/img/search.svg 1x, /img/search.svg 2x"
-                style={
-                  {
-                    "border": "none",
-                    "bottom": 0,
-                    "boxSizing": "border-box",
-                    "display": "block",
-                    "height": 0,
-                    "left": 0,
-                    "margin": "auto",
-                    "maxHeight": "100%",
-                    "maxWidth": "100%",
-                    "minHeight": "100%",
-                    "minWidth": "100%",
-                    "objectFit": undefined,
-                    "objectPosition": undefined,
-                    "padding": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                    "width": 0,
-                  }
-                }
-              />
-            </noscript>
+            <noscript />
           </span>
         </button>
       </form>
     </section>
-  </div>,
-]
+  </div>
+</div>
 `;

--- a/app/tests/pages/__snapshots__/confirmation.test.tsx.snap
+++ b/app/tests/pages/__snapshots__/confirmation.test.tsx.snap
@@ -1,24 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should match full page snapshot 1`] = `
-[
+<div>
   <h1>
     Your confirmation
-  </h1>,
+  </h1>
   <p>
     Thank you for submitting your information. If you're eligible, you should hear from WIC staff at your chosen clinic within 20 days.
-  </p>,
+  </p>
   <div
-    className="content-group-small"
+    class="content-group-small"
   >
     <h2
-      className="font-sans-xs"
+      class="font-sans-xs"
     >
       Interested in other available assistance and benefits?
     </h2>
     <p>
       <a
-        className="usa-link usa-link--external"
+        class="usa-link usa-link--external"
         href="https://dphhs.mt.gov/Assistance"
         rel="noopener noreferrer"
         target="_blank"
@@ -26,42 +26,41 @@ exports[`should match full page snapshot 1`] = `
         Learn about other assistance
       </a>
     </p>
-  </div>,
+  </div>
   <div
-    className="content-group-small"
+    class="content-group-small"
   >
     <h2
-      className="font-sans-xs"
+      class="font-sans-xs"
     >
       Do you need to submit another application for someone else?
     </h2>
     <button
-      className="usa-button usa-button--small display-block usa-button--outline margin-top-1"
-      onClick={[Function]}
+      class="usa-button usa-button--small display-block usa-button--outline margin-top-1"
     >
       Start a new application
     </button>
-  </div>,
+  </div>
   <div
-    className="content-group-small"
+    class="content-group-small"
   >
     <h2
-      className="font-sans-xs"
+      class="font-sans-xs"
     >
       Keep a copy of your confirmation for your records.
     </h2>
-  </div>,
+  </div>
   <div
-    className="review-collection margin-top-6 border-bottom-1px"
+    class="review-collection margin-top-6 border-bottom-1px"
   >
     <h2>
       Eligibility questions
     </h2>
     <dl
-      className="margin-bottom-2"
+      class="margin-bottom-2"
     >
       <div
-        className="review-element margin-bottom-3"
+        class="review-element margin-bottom-3"
       >
         <dt>
           <strong>
@@ -69,13 +68,13 @@ exports[`should match full page snapshot 1`] = `
           </strong>
         </dt>
         <dd
-          className="margin-left-0"
+          class="margin-left-0"
         >
           Eligibility.
         </dd>
       </div>
       <div
-        className="review-element margin-bottom-3"
+        class="review-element margin-bottom-3"
       >
         <dt>
           <strong>
@@ -83,13 +82,13 @@ exports[`should match full page snapshot 1`] = `
           </strong>
         </dt>
         <dd
-          className="margin-left-0"
+          class="margin-left-0"
         >
           <ul />
         </dd>
       </div>
       <div
-        className="review-element margin-bottom-3"
+        class="review-element margin-bottom-3"
       >
         <dt>
           <strong>
@@ -97,13 +96,13 @@ exports[`should match full page snapshot 1`] = `
           </strong>
         </dt>
         <dd
-          className="margin-left-0"
+          class="margin-left-0"
         >
           Eligibility.
         </dd>
       </div>
       <div
-        className="review-element margin-bottom-3"
+        class="review-element margin-bottom-3"
       >
         <dt>
           <strong>
@@ -111,24 +110,24 @@ exports[`should match full page snapshot 1`] = `
           </strong>
         </dt>
         <dd
-          className="margin-left-0"
+          class="margin-left-0"
         >
           <ul />
         </dd>
       </div>
     </dl>
-  </div>,
+  </div>
   <div
-    className="review-collection margin-top-6 border-bottom-1px"
+    class="review-collection margin-top-6 border-bottom-1px"
   >
     <h2>
       Choose a clinic
     </h2>
     <dl
-      className="margin-bottom-2"
+      class="margin-bottom-2"
     >
       <div
-        className="review-element margin-bottom-3"
+        class="review-element margin-bottom-3"
       >
         <dt>
           <strong>
@@ -136,13 +135,13 @@ exports[`should match full page snapshot 1`] = `
           </strong>
         </dt>
         <dd
-          className="margin-left-0"
+          class="margin-left-0"
         >
           <div />
         </dd>
       </div>
       <div
-        className="review-element margin-bottom-3"
+        class="review-element margin-bottom-3"
       >
         <dt>
           <strong>
@@ -150,22 +149,22 @@ exports[`should match full page snapshot 1`] = `
           </strong>
         </dt>
         <dd
-          className="margin-left-0"
+          class="margin-left-0"
         />
       </div>
     </dl>
-  </div>,
+  </div>
   <div
-    className="review-collection margin-top-6 border-bottom-1px"
+    class="review-collection margin-top-6 border-bottom-1px"
   >
     <h2>
       Contact information
     </h2>
     <dl
-      className="margin-bottom-2"
+      class="margin-bottom-2"
     >
       <div
-        className="review-element margin-bottom-3"
+        class="review-element margin-bottom-3"
       >
         <dt>
           <strong>
@@ -173,11 +172,11 @@ exports[`should match full page snapshot 1`] = `
           </strong>
         </dt>
         <dd
-          className="margin-left-0"
+          class="margin-left-0"
         />
       </div>
       <div
-        className="review-element margin-bottom-3"
+        class="review-element margin-bottom-3"
       >
         <dt>
           <strong>
@@ -185,11 +184,11 @@ exports[`should match full page snapshot 1`] = `
           </strong>
         </dt>
         <dd
-          className="margin-left-0"
+          class="margin-left-0"
         />
       </div>
       <div
-        className="review-element margin-bottom-3"
+        class="review-element margin-bottom-3"
       >
         <dt>
           <strong>
@@ -197,11 +196,11 @@ exports[`should match full page snapshot 1`] = `
           </strong>
         </dt>
         <dd
-          className="margin-left-0"
+          class="margin-left-0"
         />
       </div>
       <div
-        className="review-element margin-bottom-3"
+        class="review-element margin-bottom-3"
       >
         <dt>
           <strong>
@@ -209,10 +208,10 @@ exports[`should match full page snapshot 1`] = `
           </strong>
         </dt>
         <dd
-          className="margin-left-0"
+          class="margin-left-0"
         />
       </div>
     </dl>
-  </div>,
-]
+  </div>
+</div>
 `;

--- a/app/tests/pages/__snapshots__/contact.test.tsx.snap
+++ b/app/tests/pages/__snapshots__/contact.test.tsx.snap
@@ -1,18 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should match full page snapshot 1`] = `
-[
+<div>
   <a
-    className="usa-link"
+    class="usa-link"
     href="/choose-clinic"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onTouchStart={[Function]}
   >
     Back
-  </a>,
+  </a>
   <form
-    className="usa-form usa-form--large"
+    class="usa-form usa-form--large"
   >
     <h1>
       Contact information
@@ -21,141 +18,131 @@ exports[`should match full page snapshot 1`] = `
       All required questions are marked with an asterisk
        (
       <abbr
-        className="usa-hint usa-hint--required"
+        class="usa-hint usa-hint--required"
       >
         *
       </abbr>
       ).
     </p>
     <fieldset
-      className="usa-fieldset"
+      class="usa-fieldset"
     >
       <h2>
         What's your name?
         <abbr
-          className="usa-hint usa-hint--required"
+          class="usa-hint usa-hint--required"
         >
            *
         </abbr>
       </h2>
       <label
-        className="usa-label"
-        htmlFor="firstName"
+        class="usa-label"
+        for="firstName"
       >
         First name
         <abbr
-          className="usa-hint usa-hint--required"
+          class="usa-hint usa-hint--required"
         >
            *
         </abbr>
       </label>
       <input
-        className="usa-input"
+        class="usa-input"
         id="firstName"
         name="firstName"
-        onChange={[Function]}
         role="textbox"
         value=""
       />
       <label
-        className="usa-label"
-        htmlFor="lastName"
+        class="usa-label"
+        for="lastName"
       >
         Last name
         <abbr
-          className="usa-hint usa-hint--required"
+          class="usa-hint usa-hint--required"
         >
            *
         </abbr>
       </label>
       <input
-        className="usa-input"
+        class="usa-input"
         id="lastName"
         name="lastName"
-        onChange={[Function]}
         role="textbox"
         value=""
       />
     </fieldset>
     <fieldset
-      className="usa-fieldset"
+      class="usa-fieldset"
     >
       <h2>
         What's the best phone number to reach you at?
         <abbr
-          className="usa-hint usa-hint--required"
+          class="usa-hint usa-hint--required"
         >
            *
         </abbr>
       </h2>
       <div
-        className="usa-alert usa-alert--info usa-alert--no-icon"
+        class="usa-alert usa-alert--info usa-alert--no-icon"
         role="alert"
       >
         <div
-          className="usa-alert__body"
+          class="usa-alert__body"
         >
           <p
-            className="usa-alert__text"
+            class="usa-alert__text"
           >
             Your chosen WIC clinic will contact you via phone to set up a time for a certification appointment during business hours.
           </p>
         </div>
       </div>
       <label
-        className="usa-label"
-        htmlFor="phone"
+        class="usa-label"
+        for="phone"
       >
         Phone number
         <abbr
-          className="usa-hint usa-hint--required"
+          class="usa-hint usa-hint--required"
         >
            *
         </abbr>
       </label>
       <input
-        className="usa-input"
+        class="usa-input"
         id="phone"
-        inputMode="numeric"
+        inputmode="numeric"
         name="phone"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onMouseUp={[Function]}
         role="textbox"
         type="text"
         value=""
       />
     </fieldset>
     <fieldset
-      className="usa-fieldset"
+      class="usa-fieldset"
     >
       <h2>
         Is there anything else you'd like to share with us?
       </h2>
       <label
-        className="usa-label"
-        htmlFor="comments"
+        class="usa-label"
+        for="comments"
       >
         Comments, questions, other information
       </label>
       <textarea
-        className="usa-textarea"
+        class="usa-textarea"
         id="comments"
         name="comments"
-        onChange={[Function]}
         role="textbox"
-        value=""
       />
     </fieldset>
     <button
-      className="usa-button usa-button--small display-block margin-top-6"
-      disabled={true}
-      onClick={[Function]}
+      class="usa-button usa-button--small display-block margin-top-6"
+      disabled=""
     >
       Continue
     </button>
-  </form>,
-]
+  </form>
+</div>
 `;

--- a/app/tests/pages/__snapshots__/eligibility.test.tsx.snap
+++ b/app/tests/pages/__snapshots__/eligibility.test.tsx.snap
@@ -1,396 +1,361 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should match full page snapshot 1`] = `
-[
+<div>
   <a
-    className="usa-link"
+    class="usa-link"
     href="/how-it-works"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onTouchStart={[Function]}
   >
     Back
-  </a>,
+  </a>
   <h1>
     Check your eligibility
-  </h1>,
+  </h1>
   <p>
     All required questions are marked with an asterisk
      (
     <abbr
-      className="usa-hint usa-hint--required"
+      class="usa-hint usa-hint--required"
     >
       *
     </abbr>
     ).
-  </p>,
+  </p>
   <form
-    className="usa-form usa-form--large"
+    class="usa-form usa-form--large"
   >
     <fieldset
-      className="usa-fieldset"
+      class="usa-fieldset"
     >
       <h2>
         Do you live or work in Montana?
         <abbr
-          className="usa-hint usa-hint--required"
+          class="usa-hint usa-hint--required"
         >
            *
         </abbr>
       </h2>
       <div
-        className="usa-radio"
+        class="usa-radio"
       >
         <input
-          checked={false}
-          className="usa-radio__input usa-radio__input--tile"
+          class="usa-radio__input usa-radio__input--tile"
           id="residential-yes"
           name="residential"
-          onChange={[Function]}
           type="radio"
           value="yes"
         />
         <label
-          className="usa-radio__label"
-          htmlFor="residential-yes"
+          class="usa-radio__label"
+          for="residential-yes"
         >
           Yes
         </label>
       </div>
       <div
-        className="usa-radio"
+        class="usa-radio"
       >
         <input
-          checked={false}
-          className="usa-radio__input usa-radio__input--tile"
+          class="usa-radio__input usa-radio__input--tile"
           id="residential-no"
           name="residential"
-          onChange={[Function]}
           type="radio"
           value="no"
         />
         <label
-          className="usa-radio__label"
-          htmlFor="residential-no"
+          class="usa-radio__label"
+          for="residential-no"
         >
           No
         </label>
       </div>
     </fieldset>
     <fieldset
-      className="usa-fieldset"
+      class="usa-fieldset"
     >
       <h2>
         Please select all the following that apply to your household:
         <abbr
-          className="usa-hint usa-hint--required"
+          class="usa-hint usa-hint--required"
         >
            *
         </abbr>
       </h2>
       <div
-        className="usa-accordion usa-accordion--bordered"
+        class="usa-accordion usa-accordion--bordered"
       >
         <h3
-          className="usa-accordion__heading"
+          class="usa-accordion__heading"
         >
           <button
             aria-controls="b-a1"
-            aria-expanded={false}
-            className="usa-accordion__button"
-            onClick={[Function]}
+            aria-expanded="false"
+            class="usa-accordion__button"
             type="button"
           >
             Why are we asking this?
           </button>
         </h3>
         <div
-          className="usa-accordion__content"
-          hidden={true}
+          class="usa-accordion__content"
+          hidden=""
           id="b-a1"
         >
           There are multiple categories of eligibility, and your answers here help us understand what benefits you and/or your household may qualify for.
         </div>
       </div>
       <div
-        className="usa-checkbox"
+        class="usa-checkbox"
       >
         <input
-          checked={false}
-          className="usa-checkbox__input usa-checkbox__input--tile"
+          class="usa-checkbox__input usa-checkbox__input--tile"
           id="categorical-pregnant"
           name="categorical"
-          onChange={[Function]}
           type="checkbox"
           value="pregnant"
         />
         <label
-          className="usa-checkbox__label"
-          htmlFor="categorical-pregnant"
+          class="usa-checkbox__label"
+          for="categorical-pregnant"
         >
           I'm pregnant
         </label>
       </div>
       <div
-        className="usa-checkbox"
+        class="usa-checkbox"
       >
         <input
-          checked={false}
-          className="usa-checkbox__input usa-checkbox__input--tile"
+          class="usa-checkbox__input usa-checkbox__input--tile"
           id="categorical-baby"
           name="categorical"
-          onChange={[Function]}
           type="checkbox"
           value="baby"
         />
         <label
-          className="usa-checkbox__label"
-          htmlFor="categorical-baby"
+          class="usa-checkbox__label"
+          for="categorical-baby"
         >
           I've had a baby in the past 12 months
         </label>
       </div>
       <div
-        className="usa-checkbox"
+        class="usa-checkbox"
       >
         <input
-          checked={false}
-          className="usa-checkbox__input usa-checkbox__input--tile"
+          class="usa-checkbox__input usa-checkbox__input--tile"
           id="categorical-child"
           name="categorical"
-          onChange={[Function]}
           type="checkbox"
           value="child"
         />
         <label
-          className="usa-checkbox__label"
-          htmlFor="categorical-child"
+          class="usa-checkbox__label"
+          for="categorical-child"
         >
           I'm the parent of an infant or child under the age of 5 years old
         </label>
       </div>
       <div
-        className="usa-checkbox"
+        class="usa-checkbox"
       >
         <input
-          checked={false}
-          className="usa-checkbox__input usa-checkbox__input--tile"
+          class="usa-checkbox__input usa-checkbox__input--tile"
           id="categorical-guardian"
           name="categorical"
-          onChange={[Function]}
           type="checkbox"
           value="guardian"
         />
         <label
-          className="usa-checkbox__label"
-          htmlFor="categorical-guardian"
+          class="usa-checkbox__label"
+          for="categorical-guardian"
         >
           I'm the guardian or foster parent of an infant or child under the age of 5 years old
         </label>
       </div>
       <div
-        className="usa-checkbox"
+        class="usa-checkbox"
       >
         <input
-          checked={false}
-          className="usa-checkbox__input usa-checkbox__input--tile"
+          class="usa-checkbox__input usa-checkbox__input--tile"
           id="categorical-loss"
           name="categorical"
-          onChange={[Function]}
           type="checkbox"
           value="loss"
         />
         <label
-          className="usa-checkbox__label"
-          htmlFor="categorical-loss"
+          class="usa-checkbox__label"
+          for="categorical-loss"
         >
           I have had a pregnancy end in the last 6 months
         </label>
       </div>
       <div
-        className="usa-checkbox"
+        class="usa-checkbox"
       >
         <input
-          checked={false}
-          className="usa-checkbox__input usa-checkbox__input--tile"
+          class="usa-checkbox__input usa-checkbox__input--tile"
           id="categorical-none"
           name="categorical"
-          onChange={[Function]}
           type="checkbox"
           value="none"
         />
         <label
-          className="usa-checkbox__label"
-          htmlFor="categorical-none"
+          class="usa-checkbox__label"
+          for="categorical-none"
         >
           None of the above
         </label>
       </div>
     </fieldset>
     <fieldset
-      className="usa-fieldset"
+      class="usa-fieldset"
     >
       <h2>
         Have you or someone in your household received WIC benefits before?
         <abbr
-          className="usa-hint usa-hint--required"
+          class="usa-hint usa-hint--required"
         >
            *
         </abbr>
       </h2>
       <div
-        className="usa-radio"
+        class="usa-radio"
       >
         <input
-          checked={false}
-          className="usa-radio__input usa-radio__input--tile"
+          class="usa-radio__input usa-radio__input--tile"
           id="previouslyEnrolled-yes"
           name="previouslyEnrolled"
-          onChange={[Function]}
           type="radio"
           value="yes"
         />
         <label
-          className="usa-radio__label"
-          htmlFor="previouslyEnrolled-yes"
+          class="usa-radio__label"
+          for="previouslyEnrolled-yes"
         >
           Yes
         </label>
       </div>
       <div
-        className="usa-radio"
+        class="usa-radio"
       >
         <input
-          checked={false}
-          className="usa-radio__input usa-radio__input--tile"
+          class="usa-radio__input usa-radio__input--tile"
           id="previouslyEnrolled-no"
           name="previouslyEnrolled"
-          onChange={[Function]}
           type="radio"
           value="no"
         />
         <label
-          className="usa-radio__label"
-          htmlFor="previouslyEnrolled-no"
+          class="usa-radio__label"
+          for="previouslyEnrolled-no"
         >
           No
         </label>
       </div>
     </fieldset>
     <fieldset
-      className="usa-fieldset"
+      class="usa-fieldset"
     >
       <h2>
         Are you or someone in your household currently enrolled in any of the following programs in Montana?
         <abbr
-          className="usa-hint usa-hint--required"
+          class="usa-hint usa-hint--required"
         >
            *
         </abbr>
       </h2>
       <div
-        className="usa-checkbox"
+        class="usa-checkbox"
       >
         <input
-          checked={false}
-          className="usa-checkbox__input usa-checkbox__input--tile"
+          class="usa-checkbox__input usa-checkbox__input--tile"
           id="adjunctive-insurance"
           name="adjunctive"
-          onChange={[Function]}
           type="checkbox"
           value="insurance"
         />
         <label
-          className="usa-checkbox__label"
-          htmlFor="adjunctive-insurance"
+          class="usa-checkbox__label"
+          for="adjunctive-insurance"
         >
           Medicaid/Healthy Montana Kids Plus
         </label>
       </div>
       <div
-        className="usa-checkbox"
+        class="usa-checkbox"
       >
         <input
-          checked={false}
-          className="usa-checkbox__input usa-checkbox__input--tile"
+          class="usa-checkbox__input usa-checkbox__input--tile"
           id="adjunctive-snap"
           name="adjunctive"
-          onChange={[Function]}
           type="checkbox"
           value="snap"
         />
         <label
-          className="usa-checkbox__label"
-          htmlFor="adjunctive-snap"
+          class="usa-checkbox__label"
+          for="adjunctive-snap"
         >
           SNAP (Supplemental Nutrition Assistance Program)
         </label>
       </div>
       <div
-        className="usa-checkbox"
+        class="usa-checkbox"
       >
         <input
-          checked={false}
-          className="usa-checkbox__input usa-checkbox__input--tile"
+          class="usa-checkbox__input usa-checkbox__input--tile"
           id="adjunctive-tanf"
           name="adjunctive"
-          onChange={[Function]}
           type="checkbox"
           value="tanf"
         />
         <label
-          className="usa-checkbox__label"
-          htmlFor="adjunctive-tanf"
+          class="usa-checkbox__label"
+          for="adjunctive-tanf"
         >
           TANF (Temporary Assistance for Needy Families)
         </label>
       </div>
       <div
-        className="usa-checkbox"
+        class="usa-checkbox"
       >
         <input
-          checked={false}
-          className="usa-checkbox__input usa-checkbox__input--tile"
+          class="usa-checkbox__input usa-checkbox__input--tile"
           id="adjunctive-fdpir"
           name="adjunctive"
-          onChange={[Function]}
           type="checkbox"
           value="fdpir"
         />
         <label
-          className="usa-checkbox__label"
-          htmlFor="adjunctive-fdpir"
+          class="usa-checkbox__label"
+          for="adjunctive-fdpir"
         >
           FDPIR (Food Distribution Program on Indian Reservations)
         </label>
       </div>
       <div
-        className="usa-checkbox"
+        class="usa-checkbox"
       >
         <input
-          checked={false}
-          className="usa-checkbox__input usa-checkbox__input--tile"
+          class="usa-checkbox__input usa-checkbox__input--tile"
           id="adjunctive-none"
           name="adjunctive"
-          onChange={[Function]}
           type="checkbox"
           value="none"
         />
         <label
-          className="usa-checkbox__label"
-          htmlFor="adjunctive-none"
+          class="usa-checkbox__label"
+          for="adjunctive-none"
         >
           None of the above
         </label>
       </div>
     </fieldset>
     <button
-      className="usa-button usa-button--small display-block margin-top-6"
-      disabled={true}
-      onClick={[Function]}
+      class="usa-button usa-button--small display-block margin-top-6"
+      disabled=""
     >
       Continue
     </button>
-  </form>,
-]
+  </form>
+</div>
 `;

--- a/app/tests/pages/__snapshots__/how-it-works.test.tsx.snap
+++ b/app/tests/pages/__snapshots__/how-it-works.test.tsx.snap
@@ -1,46 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should match full page snapshot 1`] = `
-[
+<div>
   <a
-    className="usa-link"
+    class="usa-link"
     href="/"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onTouchStart={[Function]}
   >
     Back
-  </a>,
+  </a>
   <h1>
     How it works
-  </h1>,
+  </h1>
   <ol
-    className="usa-process-list"
+    class="usa-process-list"
   >
     <li
-      className="usa-process-list__item"
+      class="usa-process-list__item"
     >
       <h2
-        className="usa-process-list__heading"
+        class="usa-process-list__heading"
       >
         Check your eligibility
       </h2>
       <p
-        className="margin-top-1"
+        class="margin-top-1"
       >
         You can start applying for WIC by checking to see if you're eligible.
       </p>
     </li>
     <li
-      className="usa-process-list__item"
+      class="usa-process-list__item"
     >
       <h2
-        className="usa-process-list__heading"
+        class="usa-process-list__heading"
       >
         WIC clinic staff will schedule a certification appointment
       </h2>
       <p
-        className="margin-top-1"
+        class="margin-top-1"
       >
         <strong>
           If you are eligible
@@ -49,29 +46,29 @@ exports[`should match full page snapshot 1`] = `
       </p>
     </li>
     <li
-      className="usa-process-list__item"
+      class="usa-process-list__item"
     >
       <h2
-        className="usa-process-list__heading"
+        class="usa-process-list__heading"
       >
         Complete your appointment with your local WIC clinic
       </h2>
       <p
-        className="margin-top-1"
+        class="margin-top-1"
       >
         During your appointment, you'll need to show documentation of your income, identity, and residence.
       </p>
     </li>
-  </ol>,
+  </ol>
   <div
-    className="usa-alert usa-alert--warning usa-alert--no-icon"
+    class="usa-alert usa-alert--warning usa-alert--no-icon"
     role="alert"
   >
     <div
-      className="usa-alert__body"
+      class="usa-alert__body"
     >
       <p
-        className="usa-alert__text"
+        class="usa-alert__text"
       >
         <strong>
           Note:
@@ -79,12 +76,11 @@ exports[`should match full page snapshot 1`] = `
          this form does not guarantee enrollment in WIC; your eligibility will be confirmed when you have your first appointment with WIC.
       </p>
     </div>
-  </div>,
+  </div>
   <button
-    className="usa-button usa-button--small display-block margin-top-6"
-    onClick={[Function]}
+    class="usa-button usa-button--small display-block margin-top-6"
   >
     Check your eligibility
-  </button>,
-]
+  </button>
+</div>
 `;

--- a/app/tests/pages/__snapshots__/income.test.tsx.snap
+++ b/app/tests/pages/__snapshots__/income.test.tsx.snap
@@ -1,31 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should match full page snapshot 1`] = `
-[
+<div>
   <a
-    className="usa-link"
+    class="usa-link"
     href="/eligibility"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onTouchStart={[Function]}
   >
     Back
-  </a>,
+  </a>
   <h1>
     Check your eligibility
-  </h1>,
+  </h1>
   <p>
     All required questions are marked with an asterisk
      (
     <abbr
-      className="usa-hint usa-hint--required"
+      class="usa-hint usa-hint--required"
     >
       *
     </abbr>
     ).
-  </p>,
+  </p>
   <div
-    className="content-group"
+    class="content-group"
   >
     <h2>
       To be eligible for WIC, your 
@@ -70,35 +67,34 @@ exports[`should match full page snapshot 1`] = `
       </strong>
        A WIC staff member can answer more specific questions about your situation.
     </p>
-  </div>,
+  </div>
   <form
-    className="usa-form usa-form--large"
+    class="usa-form usa-form--large"
   >
     <fieldset
-      className="usa-fieldset"
+      class="usa-fieldset"
     >
       <h2>
         What is your household size?
       </h2>
       <div
-        className="usa-accordion usa-accordion--bordered"
+        class="usa-accordion usa-accordion--bordered"
       >
         <h3
-          className="usa-accordion__heading"
+          class="usa-accordion__heading"
         >
           <button
             aria-controls="b-a1"
-            aria-expanded={false}
-            className="usa-accordion__button"
-            onClick={[Function]}
+            aria-expanded="false"
+            class="usa-accordion__button"
             type="button"
           >
             Who counts in my household?
           </button>
         </h3>
         <div
-          className="usa-accordion__content"
-          hidden={true}
+          class="usa-accordion__content"
+          hidden=""
           id="b-a1"
         >
           <p>
@@ -110,22 +106,20 @@ exports[`should match full page snapshot 1`] = `
         </div>
       </div>
       <label
-        className="usa-label"
-        htmlFor="householdSize"
+        class="usa-label"
+        for="householdSize"
       >
         Household size
         <abbr
-          className="usa-hint usa-hint--required"
+          class="usa-hint usa-hint--required"
         >
            *
         </abbr>
       </label>
       <select
-        className="usa-select"
+        class="usa-select"
         id="householdSize"
         name="householdSize"
-        onChange={[Function]}
-        value=""
       >
         <option
           value=""
@@ -177,10 +171,10 @@ exports[`should match full page snapshot 1`] = `
       </select>
     </fieldset>
     <fieldset
-      className="usa-fieldset"
+      class="usa-fieldset"
     >
       <table
-        className="usa-table usa-table--stacked usa-table--borderless"
+        class="usa-table usa-table--stacked usa-table--borderless"
       >
         <caption>
           <h2>
@@ -215,7 +209,7 @@ exports[`should match full page snapshot 1`] = `
       </table>
       <p>
         <a
-          className="usa-link usa-link--external"
+          class="usa-link usa-link--external"
           href="https://dphhs.mt.gov/Assistance"
           rel="noopener noreferrer"
           target="_blank"
@@ -225,12 +219,11 @@ exports[`should match full page snapshot 1`] = `
       </p>
     </fieldset>
     <button
-      className="usa-button usa-button--small display-block margin-top-6"
-      disabled={true}
-      onClick={[Function]}
+      class="usa-button usa-button--small display-block margin-top-6"
+      disabled=""
     >
       Continue
     </button>
-  </form>,
-]
+  </form>
+</div>
 `;

--- a/app/tests/pages/__snapshots__/index.test.tsx.snap
+++ b/app/tests/pages/__snapshots__/index.test.tsx.snap
@@ -1,16 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should match full page snapshot 1`] = `
-[
+<div>
   <h1>
     Start an application for WIC
-  </h1>,
+  </h1>
   <strong>
     WIC (Women, Infants, and Children)
-  </strong>,
-  " is a program designed to help families and young children during an important time in growth and development.",
+  </strong>
+   is a program designed to help families and young children during an important time in growth and development.
   <ul
-    className="usa-list"
+    class="usa-list"
   >
     <li>
       There are many benefits including healthy food, breastfeeding support, nutrition education, and connections to local resources.
@@ -21,16 +21,15 @@ exports[`should match full page snapshot 1`] = `
     <li>
       WIC is a voluntary program and participation will not interfere with use of other programs like SNAP or Medicaid.
     </li>
-  </ul>,
-  "You can start the application process for WIC now. ",
+  </ul>
+  You can start the application process for WIC now. 
   <strong>
     This form should take about 10 minutes to complete.
-  </strong>,
+  </strong>
   <button
-    className="usa-button usa-button--small display-block margin-top-6"
-    onClick={[Function]}
+    class="usa-button usa-button--small display-block margin-top-6"
   >
     Get started
-  </button>,
-]
+  </button>
+</div>
 `;

--- a/app/tests/pages/__snapshots__/other-benefits.test.tsx.snap
+++ b/app/tests/pages/__snapshots__/other-benefits.test.tsx.snap
@@ -1,26 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should match full page snapshot 1`] = `
-[
+<div>
   <a
-    className="usa-link"
+    class="usa-link"
     href="/eligibility"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onTouchStart={[Function]}
   >
     Back
-  </a>,
+  </a>
   <h1>
     Your eligibility
-  </h1>,
+  </h1>
   <h2>
     Given your responses, you are likely not eligible for WIC in Montana.
-  </h2>,
+  </h2>
   <p>
     We recommend visiting 
     <a
-      className="usa-link usa-link--external"
+      class="usa-link usa-link--external"
       href="https://dphhs.mt.gov/Assistance"
       rel="noopener noreferrer"
       target="_blank"
@@ -28,11 +25,11 @@ exports[`should match full page snapshot 1`] = `
       https://dphhs.mt.gov/Assistance
     </a>
      to learn about other assistance in Montana.
-  </p>,
+  </p>
   <p>
     If you are not currently living or working in Montana, visit 
     <a
-      className="usa-link usa-link--external"
+      class="usa-link usa-link--external"
       href="https://www.signupwic.com/"
       rel="noopener noreferrer"
       target="_blank"
@@ -40,12 +37,11 @@ exports[`should match full page snapshot 1`] = `
       SignUpWIC.com
     </a>
      to find a clinic near you.
-  </p>,
+  </p>
   <button
-    className="usa-button usa-button--small display-block margin-top-6"
-    onClick={[Function]}
+    class="usa-button usa-button--small display-block margin-top-6"
   >
     Return to start page
-  </button>,
-]
+  </button>
+</div>
 `;

--- a/app/tests/pages/__snapshots__/review.test.tsx.snap
+++ b/app/tests/pages/__snapshots__/review.test.tsx.snap
@@ -1,43 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should match full page snapshot 1`] = `
-[
+<div>
   <a
-    className="usa-link"
+    class="usa-link"
     href="/contact"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-    onTouchStart={[Function]}
   >
     Back
-  </a>,
+  </a>
   <h1>
     Review and submit your information
-  </h1>,
+  </h1>
   <p>
     Review the information on this page before submitting. If you want to make changes, select "Edit" to go to the section you want to change.
-  </p>,
+  </p>
   <div
-    className="review-collection margin-top-6 border-bottom-1px"
+    class="review-collection margin-top-6 border-bottom-1px"
   >
     <h2>
       Eligibility questions
       <div
-        className="float-right"
+        class="float-right"
       >
         <button
-          className="usa-button usa-button--small display-block usa-button--unstyled margin-top-1"
-          onClick={[Function]}
+          class="usa-button usa-button--small display-block usa-button--unstyled margin-top-1"
         >
           Edit
         </button>
       </div>
     </h2>
     <dl
-      className="margin-bottom-2"
+      class="margin-bottom-2"
     >
       <div
-        className="review-element margin-bottom-3"
+        class="review-element margin-bottom-3"
       >
         <dt>
           <strong>
@@ -45,13 +41,13 @@ exports[`should match full page snapshot 1`] = `
           </strong>
         </dt>
         <dd
-          className="margin-left-0"
+          class="margin-left-0"
         >
-          Eligibility.
+          Yes
         </dd>
       </div>
       <div
-        className="review-element margin-bottom-3"
+        class="review-element margin-bottom-3"
       >
         <dt>
           <strong>
@@ -59,13 +55,20 @@ exports[`should match full page snapshot 1`] = `
           </strong>
         </dt>
         <dd
-          className="margin-left-0"
+          class="margin-left-0"
         >
-          <ul />
+          <ul>
+            <li>
+              I'm pregnant
+            </li>
+            <li>
+              I'm the guardian or foster parent of an infant or child under the age of 5 years old
+            </li>
+          </ul>
         </dd>
       </div>
       <div
-        className="review-element margin-bottom-3"
+        class="review-element margin-bottom-3"
       >
         <dt>
           <strong>
@@ -73,13 +76,13 @@ exports[`should match full page snapshot 1`] = `
           </strong>
         </dt>
         <dd
-          className="margin-left-0"
+          class="margin-left-0"
         >
-          Eligibility.
+          No
         </dd>
       </div>
       <div
-        className="review-element margin-bottom-3"
+        class="review-element margin-bottom-3"
       >
         <dt>
           <strong>
@@ -87,34 +90,40 @@ exports[`should match full page snapshot 1`] = `
           </strong>
         </dt>
         <dd
-          className="margin-left-0"
+          class="margin-left-0"
         >
-          <ul />
+          <ul>
+            <li>
+              FDPIR (Food Distribution Program on Indian Reservations)
+            </li>
+            <li>
+              SNAP (Supplemental Nutrition Assistance Program)
+            </li>
+          </ul>
         </dd>
       </div>
     </dl>
-  </div>,
+  </div>
   <div
-    className="review-collection margin-top-6 border-bottom-1px"
+    class="review-collection margin-top-6 border-bottom-1px"
   >
     <h2>
       Choose a clinic
       <div
-        className="float-right"
+        class="float-right"
       >
         <button
-          className="usa-button usa-button--small display-block usa-button--unstyled margin-top-1"
-          onClick={[Function]}
+          class="usa-button usa-button--small display-block usa-button--unstyled margin-top-1"
         >
           Edit
         </button>
       </div>
     </h2>
     <dl
-      className="margin-bottom-2"
+      class="margin-bottom-2"
     >
       <div
-        className="review-element margin-bottom-3"
+        class="review-element margin-bottom-3"
       >
         <dt>
           <strong>
@@ -122,13 +131,15 @@ exports[`should match full page snapshot 1`] = `
           </strong>
         </dt>
         <dd
-          className="margin-left-0"
+          class="margin-left-0"
         >
-          <div />
+          <div>
+            12345
+          </div>
         </dd>
       </div>
       <div
-        className="review-element margin-bottom-3"
+        class="review-element margin-bottom-3"
       >
         <dt>
           <strong>
@@ -136,32 +147,55 @@ exports[`should match full page snapshot 1`] = `
           </strong>
         </dt>
         <dd
-          className="margin-left-0"
-        />
+          class="margin-left-0"
+        >
+          <div
+            class="clinic-info"
+          >
+            <div
+              class="clinic-name"
+            >
+              CLINIC ZERO
+            </div>
+            <div
+              class=""
+            >
+              <div
+                class="clinic-street-address"
+              >
+                0000 St, Helena, MT 00000
+              </div>
+              <div
+                class="clinic-phone"
+              >
+                (000) 000-0000
+              </div>
+            </div>
+          </div>
+        </dd>
       </div>
     </dl>
-  </div>,
+  </div>
   <div
-    className="review-collection margin-top-6 border-bottom-1px"
+    class="review-collection margin-top-6 border-bottom-1px"
   >
     <h2>
       Contact information
       <div
-        className="float-right"
+        class="float-right"
       >
         <button
-          className="usa-button usa-button--small display-block usa-button--unstyled margin-top-1"
-          onClick={[Function]}
+          class="usa-button usa-button--small display-block usa-button--unstyled margin-top-1"
         >
           Edit
         </button>
       </div>
     </h2>
     <dl
-      className="margin-bottom-2"
+      class="margin-bottom-2"
     >
       <div
-        className="review-element margin-bottom-3"
+        class="review-element margin-bottom-3"
       >
         <dt>
           <strong>
@@ -169,11 +203,13 @@ exports[`should match full page snapshot 1`] = `
           </strong>
         </dt>
         <dd
-          className="margin-left-0"
-        />
+          class="margin-left-0"
+        >
+          Jack
+        </dd>
       </div>
       <div
-        className="review-element margin-bottom-3"
+        class="review-element margin-bottom-3"
       >
         <dt>
           <strong>
@@ -181,11 +217,13 @@ exports[`should match full page snapshot 1`] = `
           </strong>
         </dt>
         <dd
-          className="margin-left-0"
-        />
+          class="margin-left-0"
+        >
+          O Lantern
+        </dd>
       </div>
       <div
-        className="review-element margin-bottom-3"
+        class="review-element margin-bottom-3"
       >
         <dt>
           <strong>
@@ -193,11 +231,13 @@ exports[`should match full page snapshot 1`] = `
           </strong>
         </dt>
         <dd
-          className="margin-left-0"
-        />
+          class="margin-left-0"
+        >
+          123-123-1234
+        </dd>
       </div>
       <div
-        className="review-element margin-bottom-3"
+        class="review-element margin-bottom-3"
       >
         <dt>
           <strong>
@@ -205,16 +245,17 @@ exports[`should match full page snapshot 1`] = `
           </strong>
         </dt>
         <dd
-          className="margin-left-0"
-        />
+          class="margin-left-0"
+        >
+          comments
+        </dd>
       </div>
     </dl>
-  </div>,
+  </div>
   <button
-    className="usa-button usa-button--small display-block margin-top-6"
-    onClick={[Function]}
+    class="usa-button usa-button--small display-block margin-top-6"
   >
     Submit
-  </button>,
-]
+  </button>
+</div>
 `;

--- a/app/tests/pages/choose-clinic.test.tsx
+++ b/app/tests/pages/choose-clinic.test.tsx
@@ -17,7 +17,6 @@ import {
   testActionButtonReviewMode,
   testActionButtonRoute,
   testBackLink,
-  testSnapshot,
 } from '../helpers/sharedTests'
 
 /**
@@ -49,7 +48,7 @@ function setZipCode(mockSession: SessionData, type: string): SessionData {
 
 it('should match full page snapshot', () => {
   const { mockSession } = setup(route)
-  testSnapshot(
+  const { container } = render(
     <ChooseClinic
       session={mockSession}
       setSession={setMockSession}
@@ -57,6 +56,7 @@ it('should match full page snapshot', () => {
       forwardRoute={forwardRoute}
     />
   )
+  expect(container).toMatchSnapshot()
 })
 
 it('should pass accessibility scan', async () => {

--- a/app/tests/pages/confirmation.test.tsx
+++ b/app/tests/pages/confirmation.test.tsx
@@ -7,7 +7,7 @@ import * as sessionModule from '@src/hooks/useSessionStorage'
 import { initialSessionData } from '@utils/sessionData'
 
 import { setMockSession, setup } from '../helpers/setup'
-import { testAccessibility, testSnapshot } from '../helpers/sharedTests'
+import { testAccessibility } from '../helpers/sharedTests'
 
 /**
  * Test setup
@@ -21,13 +21,14 @@ const route = '/confirmation'
 
 it('should match full page snapshot', () => {
   const { mockSession } = setup(route)
-  testSnapshot(
+  const { container } = render(
     <Confirmation
       sessionKey="mockSessionKey"
       session={mockSession}
       setSession={setMockSession}
     />
   )
+  expect(container).toMatchSnapshot()
 })
 
 it('should pass accessibility scan', async () => {

--- a/app/tests/pages/contact.test.tsx
+++ b/app/tests/pages/contact.test.tsx
@@ -9,7 +9,6 @@ import {
   testActionButtonReviewMode,
   testActionButtonRoute,
   testBackLink,
-  testSnapshot,
 } from '../helpers/sharedTests'
 import { invalidContactCombinations } from '../utils/dataValidation/isValidContact.test'
 
@@ -27,7 +26,7 @@ const forwardRoute = '/review'
 
 it('should match full page snapshot', () => {
   const { mockSession } = setup(route)
-  testSnapshot(
+  const { container } = render(
     <Contact
       session={mockSession}
       setSession={setMockSession}
@@ -35,6 +34,7 @@ it('should match full page snapshot', () => {
       forwardRoute={forwardRoute}
     />
   )
+  expect(container).toMatchSnapshot()
 })
 
 it('should pass accessibility scan', async () => {

--- a/app/tests/pages/eligibility.test.tsx
+++ b/app/tests/pages/eligibility.test.tsx
@@ -10,7 +10,6 @@ import {
   testActionButtonReviewMode,
   testActionButtonRoute,
   testBackLink,
-  testSnapshot,
 } from '../helpers/sharedTests'
 import { invalidEligibilityCombinations } from '../utils/dataValidation/isValidEligibility.test'
 
@@ -28,7 +27,7 @@ const forwardRoute = '/income'
 
 it('should match full page snapshot', () => {
   const { mockSession } = setup(route)
-  testSnapshot(
+  const { container } = render(
     <Eligibility
       session={mockSession}
       setSession={setMockSession}
@@ -36,6 +35,7 @@ it('should match full page snapshot', () => {
       forwardRoute={forwardRoute}
     />
   )
+  expect(container).toMatchSnapshot()
 })
 
 it('should pass accessibility scan', async () => {

--- a/app/tests/pages/how-it-works.test.tsx
+++ b/app/tests/pages/how-it-works.test.tsx
@@ -1,10 +1,11 @@
+import { render } from '@testing-library/react'
+
 import HowItWorks from '@pages/how-it-works'
 
 import { setup } from '../helpers/setup'
 import {
   testAccessibility,
   testActionButtonRoute,
-  testSnapshot,
 } from '../helpers/sharedTests'
 
 /**
@@ -21,7 +22,10 @@ const forwardRoute = '/eligibility'
 
 it('should match full page snapshot', () => {
   setup(route)
-  testSnapshot(<HowItWorks backRoute={backRoute} forwardRoute={forwardRoute} />)
+  const { container } = render(
+    <HowItWorks backRoute={backRoute} forwardRoute={forwardRoute} />
+  )
+  expect(container).toMatchSnapshot()
 })
 
 it('should pass accessibility scan', async () => {

--- a/app/tests/pages/income.test.tsx
+++ b/app/tests/pages/income.test.tsx
@@ -9,7 +9,6 @@ import {
   testActionButtonReviewMode,
   testActionButtonRoute,
   testBackLink,
-  testSnapshot,
 } from '../helpers/sharedTests'
 
 /**
@@ -27,7 +26,7 @@ const mockHouseholdSize = '1'
 
 it('should match full page snapshot', () => {
   const { mockSession } = setup(route)
-  testSnapshot(
+  const { container } = render(
     <Income
       session={mockSession}
       setSession={setMockSession}
@@ -35,6 +34,7 @@ it('should match full page snapshot', () => {
       forwardRoute={forwardRoute}
     />
   )
+  expect(container).toMatchSnapshot()
 })
 
 it('should pass accessibility scan', async () => {

--- a/app/tests/pages/index.test.tsx
+++ b/app/tests/pages/index.test.tsx
@@ -1,10 +1,11 @@
+import { render } from '@testing-library/react'
+
 import Index from '@pages/index'
 
 import { setup } from '../helpers/setup'
 import {
   testAccessibility,
   testActionButtonRoute,
-  testSnapshot,
 } from '../helpers/sharedTests'
 
 /**
@@ -20,7 +21,8 @@ const forwardRoute = '/how-it-works'
 
 it('should match full page snapshot', () => {
   setup(route)
-  testSnapshot(<Index forwardRoute={forwardRoute} />)
+  const { container } = render(<Index forwardRoute={forwardRoute} />)
+  expect(container).toMatchSnapshot()
 })
 
 it('should pass accessibility scan', async () => {

--- a/app/tests/pages/other-benefits.test.tsx
+++ b/app/tests/pages/other-benefits.test.tsx
@@ -7,11 +7,7 @@ import * as sessionModule from '@src/hooks/useSessionStorage'
 import { initialSessionData } from '@utils/sessionData'
 
 import { setMockSession, setup } from '../helpers/setup'
-import {
-  testAccessibility,
-  testBackLink,
-  testSnapshot,
-} from '../helpers/sharedTests'
+import { testAccessibility, testBackLink } from '../helpers/sharedTests'
 
 /**
  * Test setup
@@ -27,7 +23,7 @@ const forwardRoute = '/'
 
 it('should match full page snapshot', () => {
   const { mockSession } = setup(route)
-  testSnapshot(
+  const { container } = render(
     <OtherBenefits
       sessionKey="mockSessionKey"
       setSession={setMockSession}
@@ -36,6 +32,7 @@ it('should match full page snapshot', () => {
       forwardRoute={forwardRoute}
     />
   )
+  expect(container).toMatchSnapshot()
 })
 
 it('should pass accessibility scan', async () => {

--- a/app/tests/pages/review.test.tsx
+++ b/app/tests/pages/review.test.tsx
@@ -8,11 +8,7 @@ import Review from '@pages/review'
 
 import { getMockSessionData } from '../helpers/mockData'
 import { setMockSession, setup } from '../helpers/setup'
-import {
-  testAccessibility,
-  testBackLink,
-  testSnapshot,
-} from '../helpers/sharedTests'
+import { testAccessibility, testBackLink } from '../helpers/sharedTests'
 
 /**
  * Test setup
@@ -37,7 +33,7 @@ beforeEach(() => {
 it('should match full page snapshot', () => {
   setup(route)
   const mockSession = getMockSessionData()
-  testSnapshot(
+  const { container } = render(
     <Review
       session={mockSession}
       setSession={setMockSession}
@@ -46,6 +42,7 @@ it('should match full page snapshot', () => {
       baseUrl={baseUrl}
     />
   )
+  expect(container).toMatchSnapshot()
 })
 
 it('should pass accessibility scan', async () => {

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -3618,13 +3618,6 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-test-renderer@^18.0.0":
-  version "18.0.0"
-  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-18.0.0.tgz#7b7f69ca98821ea5501b21ba24ea7b6139da2243"
-  integrity sha512-C7/5FBJ3g3sqUahguGi03O79b8afNeSD6T8/GU50oQrJCU0bVCCGQHaGKUbg2Ce8VQEEqTw8/HiS6lXHHdgkdQ==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react@*", "@types/react@^18.0.9":
   version "18.0.15"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.15.tgz#d355644c26832dc27f3e6cbf0c4f4603fc4ab7fe"


### PR DESCRIPTION
## Ticket

N/A

## Changes
> What was added, updated, or removed in this PR.

- Remove less accurate snapshot test helper `testSnapshot()`
- Use more accurate snapshot testing using `render()`

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

Per a couple helpful pointers (see [1](https://github.com/navapbc/wic-mt-demo-project-eligibility-screener/pull/146#discussion_r1009650286) and [2](https://github.com/navapbc/wic-mt-demo-project-eligibility-screener/pull/142#discussion_r1009616781)), @aligg and @sawyerh pointed out that we were using a slightly unusual way of handling snapshot testing. Even though this is the model that the [Jest documentation](https://jestjs.io/docs/snapshot-testing) uses...

```js
import renderer from 'react-test-renderer';
import Link from '../Link';

it('renders correctly', () => {
  const tree = renderer
    .create(<Link page="http://www.facebook.com">Facebook</Link>)
    .toJSON();
  expect(tree).toMatchSnapshot();
});
```

... it's not as accurate as:

```js
const { container } = render(<Accordion {...testProps} />)
expect(container).toMatchSnapshot()
```

This PR replaces all instances that use react-test-renderer with directly calling `render()`.

## Testing
> Screenshots, GIF demos, code examples or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

Use `yarn test` to confirm no regressions in testing.
