### PR TITLE
Set NEXT_PUBLIC_DEMO_MODE as a build arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To turn off demo mode, configure the following environment variables:
 - `API_AUTH_TOKEN`: The authentication token required to connect to the API
 
 If you are running in development (i.e. using `yarn dev`), then set the environment variable `NEXT_PUBLIC_DEMO_MODE` to `"false"`.
-If you are running in production (i.e. using `yarn start`), then set the docker build argument `NEXT_PUBLIC_DEMO_MODE` to `"false"`.
+If you are running in production (i.e. using `yarn start`), then set the docker build argument `NEXT_PUBLIC_DEMO_MODE` to `"false"`. Do not set the environment variable when in production. Nextjs will report console errors if you do.
 
 See `/docker-compose.yml` and `/app/Dockerfile` for more details.
 

--- a/README.md
+++ b/README.md
@@ -12,16 +12,19 @@ This template includes setup for:
 
 ## How to Run
 
-### Environment Variables
+### Connecting to API
 
-The eligibility screener application is designed to send data it collects to an API (see [example](https://github.com/navapbc/wic-mt-demo-project-mock-api)). To do so, configure the following environment variables:
+The eligibility screener application is designed to send data it collects to an API (see [example](https://github.com/navapbc/wic-mt-demo-project-mock-api)). However, by default, this application assumes that the application is NOT running in tandem with an API and will run in "demo mode".
+
+To turn off demo mode, configure the following environment variables:
 
 - `API_HOST`: The url of the API including http/s protocool
 - `API_AUTH_TOKEN`: The authentication token required to connect to the API
 
-If you are not running the application in tandem with an API, then set the following environment variable to `true`
+If you are running in development (i.e. using `yarn dev`), then set the environment variable `NEXT_PUBLIC_DEMO_MODE` to `"false"`.
+If you are running in production (i.e. using `yarn start`), then set the docker build argument `NEXT_PUBLIC_DEMO_MODE` to `"false"`.
 
-- `NEXT_PUBLIC_DEMO_MODE`: `true` will run the eligibility screener in demo mode, where data will not be collected or sent. `false` requires the above environment variables to be set
+See `/docker-compose.yml` and `/app/Dockerfile` for more details.
 
 ### Without Docker
 

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -12,6 +12,9 @@ WORKDIR /srv
 RUN yarn install --frozen-lockfile
 # Copy all the remaining application files (ignoring files in .dockerignore) to the working directory.
 COPY . /srv
+# The default setting for NEXT_PUBLIC_DEMO_MODE is true. This will deploy the application in demo mode.
+# Override this with a build arg set to "false" to connect to the mock API.
+ARG NEXT_PUBLIC_DEMO_MODE=true
 # Build the application.
 RUN yarn build
 # Run the application.

--- a/app/src/components/Layout.tsx
+++ b/app/src/components/Layout.tsx
@@ -9,9 +9,11 @@ type Props = {
 }
 
 const Layout = ({ children }: Props) => {
+  const demoMode = process.env.NEXT_PUBLIC_DEMO_MODE ?? 'false'
+
   return (
     <div className="container">
-      {process.env.NEXT_PUBLIC_DEMO_MODE === 'true' && (
+      {demoMode === 'true' && (
         <Alert
           alertBody="demoAlertBanner.text"
           type="warning"

--- a/app/src/pages/confirmation.tsx
+++ b/app/src/pages/confirmation.tsx
@@ -40,12 +40,14 @@ const Confirmation: NextPage<ClearablePage> = (props: ClearablePage) => {
     setSession(cloneDeep(initialSessionData))
   }
 
+  const demoMode = process.env.NEXT_PUBLIC_DEMO_MODE ?? 'false'
+
   return (
     <>
       <h1>
         <TransLine i18nKey="Confirmation.title" />
       </h1>
-      {process.env.NEXT_PUBLIC_DEMO_MODE === 'true' && (
+      {demoMode === 'true' && (
         <Alert alertBody="demoAlertNotice.text" type="warning" icon={true} />
       )}
       <p>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,25 @@
 # See https://docs.docker.com/compose/compose-file/compose-versioning/
 version: '3'
 
+# For this application, we are using Next.js's environment variable feature to expose
+# an environment variable to the browser. See:
+# https://nextjs.org/docs/basic-features/environment-variables#exposing-environment-variables-to-the-browser
+# By default, this argument is set in the Dockerfile.
+# If you are using `yarn dev` (development mode), then you can override this as an
+# environment variable using docker compose's `environment` control.
+# If you are using `yarn start` (production mode), then you can override this as a build argument.
 services:
   # Define a service for the Next.js application.
   nextjs:
-    build: ./app
+    build:
+      context: ./app
+      # Uncomment to turn off demo mode when using `yarn start`
+      # args:
+      #   - NEXT_PUBLIC_DEMO_MODE="false"
     command: ["yarn", "dev"]
-    environment:
-      # Comment out the next line to test connecting with the API.
-      - NEXT_PUBLIC_DEMO_MODE=true
+    # Uncomment to turn off demo mode when using `yarn dev`
+    # environment:
+    #   - NEXT_PUBLIC_DEMO_MODE="false"
     ports:
       # Expose a port to access the application.
       - 3000:3000


### PR DESCRIPTION
## Ticket

- N/A

## Changes
> What was added, updated, or removed in this PR.

- Set `NEXT_PUBLIC_DEMO_MODE` as a docker build argument 
- Refactored how `NEXT_PUBLIC_DEMO_MODE` is handled
- Add additional documentation about demo mode

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

https://wic-eligibility.demo.navapbc.com wasn't showing the demo mode even after @aplybeah  had deployed the `NEXT_PUBLIC_DEMO_MODE` env var like I asked. It turns out that I asked for the wrong thing. 

Next.js does support environment variables in the browser. However, those environment variables [need to be present at build time](https://nextjs.org/docs/basic-features/environment-variables#exposing-environment-variables-to-the-browser) and, through experimentation, I discovered that if they are present at run time, Next.js actually throws errors: 

> Uncaught Error: Minified React error #423; visit https://reactjs.org/docs/error-decoder.html?invariant=423 for the full message or use the non-minified dev environment for full errors and additional helpful warnings.

I've fixed this by making `NEXT_PUBLIC_DEMO_MODE` into a [Dockerfile build arg with a default value](https://docs.docker.com/engine/reference/builder/#default-values). When running `yarn start`, this can be overridden at build time. When running `yarn dev`, this can be overridden with an environment variable.

## Testing
> Screenshots, GIF demos, code examples or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

I manually ran our cd.yml steps to push a local build to ECR and deploy it. See https://wic-eligibility.demo.navapbc.com/ for the fixed version.
