### PR TITLE
[Post-Demo] Migrate Terraform code from project repo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,25 @@ services:
       - ./app:/srv
       # Use a named volume for the node_modules so that the container uses the guest machine's node_modules dir instead of the host machine's node_modules directory, which might be divergent.
       - nextjs_nodemodules:/srv/node_modules
-
+  # eligibility-screener:
+  #   build:
+  #     context: ./eligibility-screener/app
+  #   # Run in development mode
+  #   command: ["yarn", "dev"]
+  #   # Load environment variables for local development
+  #   env_file: ./mock-api/app/local.env
+  #   environment:
+  #     - API_HOST=http://mock-api:8080
+  #     - NEXT_PUBLIC_DEMO_MODE="false"
+  #   # Fix running on Apple silicon
+  #   platform: linux/amd64
+  #   ports:
+  #     # Expose a port to access the application.
+  #     - 3000:3000
+  #     # Expose a port for storybook.
+  #     - 6006:6006
+  #   volumes:
+  #     # Use a named volume for the node_modules so that the container uses the guest machine's node_modules dir instead of the host machine's node_modules directory, which might be divergent.
+  #     - nextjs_nodemodules:/srv/node_modules
 volumes:
   nextjs_nodemodules:

--- a/infra/ecr.tf
+++ b/infra/ecr.tf
@@ -1,0 +1,4 @@
+resource "aws_ecr_repository" "eligibility-screener-repository" {
+  name                 = "eligibility-screener-repo"
+  image_tag_mutability = "MUTABLE"
+}

--- a/infra/eligibility_screener/README.md
+++ b/infra/eligibility_screener/README.md
@@ -1,0 +1,55 @@
+## General Technical Documentation
+
+### Development
+
+For this project, we have dockerized each component and use `docker-compose`.
+
+### Continuous Integration
+
+For CI, we are using [Github Actions](https://github.com/features/actions). In each repo, the primary branch is `main` and we have configured it as a [protected branch](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/managing-a-branch-protection-rule). To merge to `main`, a Pull Request must be made, status checks must pass, and the branch must be up to date.
+
+For our project work, each PR is required to have at least one code review and approval. This is enforced in Github in this project repo.
+
+We have enabled the following status checks in each app repo:
+
+- typechecking
+- linting
+- testing
+- security scanning
+
+The eligibility screener repo also includes accessibility scanning with [jest-axe](https://github.com/nickcolley/jest-axe).  
+
+### Infrastructure
+
+We are using [Terraform](https://www.terraform.io) to manage our infrastructure as code.
+
+We are hosting our environments and networking resources in AWS.
+
+**Environments**
+There is a `test` environment enabled for both the eligibility screener and the mock api. Each
+application has a `main.tf` which serves as a template for creating the relevant resources required
+for hosting the application in different environments. (e.g. ECS tasks, security groups)
+
+**Secrets**
+Secrets are managed in AWS Parameter Store. Variables should be referenced using Terraform's
+`aws_ssm_parameter` data resources.
+
+**Application environment variables**
+- Many of the resources in each application (e.g. cluster names, load balancers) are prefixed with the name of the environment.
+
+## Local Development
+
+To run the eligibility screener and the Mock API in development mode locally:
+
+1. Navigate to the root directory of this repo
+2. Clone the eligibility screener repo: `git clone git@github.com:navapbc/wic-mt-demo-project-eligibility-screener.git eligibility-screener`
+3. Clone the mock API repo: `git clone git@github.com:navapbc/wic-mt-demo-project-mock-api.git mock-api`
+4. Build the docker images and start the containers (it will start 3 containers: mock api, eligibility screener, postgresql): `docker-compose up -d --build`
+5. If this is the first time you are running the mock API, then it will crash because the database migrations haven't been run yet. Run them and then restart the container: `docker-compose run --rm mock-api poetry run db-migrate-up && docker-compose up -d`
+6. Run storybook: `docker-compose exec eligibility-screener yarn storybook`
+
+Now you can navigate to:
+
+- `localhost:3000` to access the eligibility screener
+- `localhost:8080/v1/docs` to access the swagger docs
+- `localhost:6006` to access storybook

--- a/infra/eligibility_screener/cloudwatch.tf
+++ b/infra/eligibility_screener/cloudwatch.tf
@@ -1,0 +1,7 @@
+# ----------------------------------------------
+# Eligibility Screener
+# ----------------------------------------------
+resource "aws_cloudwatch_log_group" "eligibility_screener" {
+  name              = "screener"
+  retention_in_days = 90
+}

--- a/infra/eligibility_screener/constants/outputs.tf
+++ b/infra/eligibility_screener/constants/outputs.tf
@@ -1,0 +1,13 @@
+output "screener_tags" {
+
+  value = {
+    project    = "eligibility-screener"
+    owner      = "wic-mt-demo"
+    repository = "https://github.com/navapbc/wic-mt-demo-project-eligibility-screener"
+  }
+}
+
+output "vpc_id" {
+  value       = "vpc-032e680f92b88bb68"
+  description = "Default VPC provided by AWS"
+}

--- a/infra/eligibility_screener/environments/test/.terraform.lock.hcl
+++ b/infra/eligibility_screener/environments/test/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.16.0"
+  constraints = "~> 4.16.0"
+  hashes = [
+    "h1:jmf/sbrsF1//4DG3QdPzbjCNsPUCp66g7ysuyj8QECc=",
+    "zh:0aa204fead7c431796386cc9e73ccda9a185f37e46d4b6475ff3f56ad4f15101",
+    "zh:130396f5da1650f4d6949e67ec44e0f408a529b7f76c48701a7bf21ba6949bbc",
+    "zh:271bfa95bc1332676a81d3f01ba1b5a188abf26df475ca9f25972c68935b6ee9",
+    "zh:51bc600c6c00292c6cb00ca460c555fb2cafd11d5fe9c5dc7d4ce62ec71874f8",
+    "zh:6ece49ba67e484777e1588a08b043c186aa896b5189b0a5056eb7838c566f63e",
+    "zh:994402e0973b12f2266f2d3ad00f000b2e2f3ee6961631aeab32688c0c4e07fd",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9e9ef874b11dfb1960aa18e1254ee430142cb583f721a2ed44b608ddf652db57",
+    "zh:bb1755cd1dd39e0caf98efb1ccb5b03323f77ba13b3f5531bfe28aded7750db0",
+    "zh:e5e73ddc1e3d0c0311be90176152c07f0d27af377a95baab72c6f00622461f46",
+    "zh:e7fd8313107ab7f63297b8440b0ccf08a7b56a329ae110ad9b6ef51959939a20",
+    "zh:f095a3f10331b3a91527822a2a881a6714c2e40ee20a14b3c127340c540e37e5",
+  ]
+}

--- a/infra/eligibility_screener/environments/test/main.tf
+++ b/infra/eligibility_screener/environments/test/main.tf
@@ -1,0 +1,25 @@
+locals {
+  environment_name = "test"
+}
+
+provider "aws" {
+  region  = "us-east-1"
+  profile = "wic-mt"
+}
+
+terraform {
+  required_version = "1.2.0"
+
+  backend "s3" {
+    bucket         = "wic-mt-tf-state"
+    key            = "terraform/screener/test.tfstate"
+    region         = "us-east-1"
+    encrypt        = "true"
+    dynamodb_table = "wic_terraform_locks"
+    profile        = "wic-mt" # may need to rethink this; no profile defaults to env variables
+  }
+}
+module "template" {
+  source           = "../../template"
+  environment_name = local.environment_name
+}

--- a/infra/eligibility_screener/template/ecs.tf
+++ b/infra/eligibility_screener/template/ecs.tf
@@ -1,0 +1,207 @@
+# ---------------------------------------
+#
+# Locals
+#
+# ---------------------------------------
+locals {
+  container_name = "${var.environment_name}-eligibility-screener-container"
+}
+
+# ---------------------------------------
+#
+# Security Groups
+#
+# ---------------------------------------
+resource "aws_security_group" "allow-screener-traffic" {
+  name        = "allow_screener_traffic"
+  description = "This rule blocks all traffic unless it is HTTPS for the eligibility screener"
+  vpc_id      = module.constants.vpc_id
+
+  ingress {
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow traffic from internet"
+    from_port   = 3000
+    to_port     = 3000
+    protocol    = "tcp"
+  }
+  egress {
+    description      = "allow all outbound traffic from screener"
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+}
+
+resource "aws_security_group" "allow-lb-traffic" {
+  name        = "screener_load_balancer_sg"
+  description = "Allows load balancers to communicate with tasks"
+  vpc_id      = module.constants.vpc_id
+
+  ingress {
+    description      = "HTTP traffic from anywhere"
+    from_port        = 80
+    to_port          = 80
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+  ingress {
+    description      = "HTTPS traffic from anywhere"
+    from_port        = 443
+    to_port          = 443
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+  egress {
+    description      = "allow all outbound traffic from load balancer"
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+}
+
+# ---------------------------------------
+#
+# Load Balancing
+#
+# ---------------------------------------
+
+resource "aws_lb" "eligibility-screener" {
+  name               = "${var.environment_name}-screener-lb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.allow-lb-traffic.id]
+  subnets = [
+    "subnet-05b0618f4ef1a808c",
+    "subnet-06067596a1f981034",
+    "subnet-06b4ec8ff6311f69d",
+    "subnet-08d7f1f9802fd20c4",
+    "subnet-09c317466f27bb9bb",
+    "subnet-0ccc97c07aa49a0ae"
+  ] # find a way to map all the default ones here; hardcoding for now
+  ip_address_type        = "ipv4"
+  desync_mitigation_mode = "defensive"
+}
+
+resource "aws_lb_target_group" "eligibility-screener" {
+  name        = "${var.environment_name}-screener-lb"
+  port        = 3000
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = module.constants.vpc_id
+  health_check {
+    enabled = true
+    port    = 3000
+  }
+}
+
+resource "aws_lb_listener" "screener_secure" {
+  load_balancer_arn = aws_lb.eligibility-screener.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = "arn:aws:acm:us-east-1:546642427916:certificate/91022588-849d-4b53-8ad1-b649607795ae"
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.eligibility-screener.arn
+  }
+}
+
+resource "aws_lb_listener" "screener" {
+  load_balancer_arn = aws_lb.eligibility-screener.arn
+  port              = 80
+  protocol          = "HTTP"
+  default_action {
+    type = "redirect"
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+# ---------------------------------------
+#
+# ECS
+#
+# ---------------------------------------
+resource "aws_ecs_cluster" "eligibility-screener-ecs-cluster" {
+  name = var.environment_name
+}
+
+resource "aws_ecs_service" "eligibility-screener-ecs-service" {
+  name            = "${var.environment_name}-screener-ecs-service"
+  cluster         = aws_ecs_cluster.eligibility-screener-ecs-cluster.id
+  task_definition = aws_ecs_task_definition.eligibility-screener-ecs-task-definition.arn
+  launch_type     = "FARGATE"
+  network_configuration {
+    subnets          = ["subnet-06b4ec8ff6311f69d"]
+    assign_public_ip = true
+    security_groups  = [aws_security_group.allow-screener-traffic.id]
+  }
+  desired_count = 1
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+  force_new_deployment = true
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.eligibility-screener.arn
+    container_name   = local.container_name # from the task definition 
+    container_port   = 3000                 # from the exposed docker container on the screener
+  }
+}
+data "aws_cloudwatch_log_group" "eligibility_screener" {
+  name = "screener"
+}
+data "aws_ssm_parameter" "random_api_key" {
+  name = "/common/mock_api_db/API_AUTH_TOKEN"
+}
+
+resource "aws_ecs_task_definition" "eligibility-screener-ecs-task-definition" {
+  family                   = "${var.environment_name}-screener-task-definition"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  memory                   = "1024"
+  cpu                      = "512"
+  execution_role_arn       = "arn:aws:iam::546642427916:role/wic-mt-task-executor"
+  container_definitions = jsonencode([
+    {
+      name      = local.container_name
+      image     = "546642427916.dkr.ecr.us-east-1.amazonaws.com/eligibility-screener-repo:latest-${var.environment_name}"
+      memory    = 1024
+      cpu       = 512
+      essential = true
+      portMappings = [
+        {
+          containerPort : 3000
+        }
+      ],
+      environment : [
+        {
+          "name" : "API_HOST"
+          "value" : "http://test-mock-api-lb-2033452615.us-east-1.elb.amazonaws.com:80" # hardcoded for persistience, mockapi load balancer DNS name
+        },
+        {
+          "name" : "API_AUTH_TOKEN"
+          "value" : "${data.aws_ssm_parameter.random_api_key.value}"
+        }
+      ],
+      logConfiguration = {
+        logDriver = "awslogs",
+        options = {
+          "awslogs-group"         = "${data.aws_cloudwatch_log_group.eligibility_screener.name}",
+          "awslogs-region"        = "us-east-1",
+          "awslogs-stream-prefix" = "screener"
+        }
+      }
+    }
+  ])
+}

--- a/infra/eligibility_screener/template/main.tf
+++ b/infra/eligibility_screener/template/main.tf
@@ -1,0 +1,42 @@
+# this file should contain information about tf versions and required providers
+
+terraform {
+  required_version = "1.2.0"
+
+  backend "s3" {
+    bucket         = "wic-mt-tf-state"
+    key            = "terraform/screener/test.tfstate"
+    region         = "us-east-1"
+    encrypt        = "true"
+    dynamodb_table = "wic_terraform_locks"
+    profile        = "wic-mt" # may need to rethink this; no profile defaults to env variables
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.16.0"
+    }
+  }
+}
+
+module "constants" {
+  source = "../constants"
+}
+
+provider "aws" {
+  region  = "us-east-1"
+  profile = "wic-mt"
+  default_tags {
+    tags = merge(
+      module.constants.screener_tags, {
+        environment = var.environment_name
+    })
+  }
+}
+data "aws_region" "current" {
+}
+
+data "aws_caller_identity" "current" {
+
+}

--- a/infra/eligibility_screener/template/variables.tf
+++ b/infra/eligibility_screener/template/variables.tf
@@ -1,0 +1,4 @@
+variable "environment_name" {
+  description = "Name of the environment"
+  type        = string
+}

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -1,0 +1,43 @@
+resource "aws_ecr_repository_policy" "eligibility-screener-repo-policy" {
+  repository = aws_ecr_repository.eligibility-screener-repository.name
+  policy     = data.aws_iam_policy_document.ecr-perms.json
+}
+
+data "aws_iam_policy_document" "ecr-perms" {
+  statement {
+    sid = "ECRPerms"
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchGetImage",
+      "ecr:CompleteLayerUpload",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:GetLifecyclePolicy",
+      "ecr:InitiateLayerUpload",
+      "ecr:PutImage",
+      "ecr:UploadLayerPart"
+    ]
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+  }
+}
+
+# add ecr perms (push)
+data "aws_iam_policy_document" "deploy_action" {
+  statement {
+    sid     = "WICUpdateECR"
+    actions = ["ecs:UpdateCluster", "ecs:UpdateService", "ecs:DescribeClusters", "ecs:DescribeServices", "ecr:*"]
+    resources = [
+      "arn:aws:ecs:us-east-1:546642427916:service/${var.environment_name}/*",
+      "arn:aws:ecs:us-east-1:546642427916:cluster/${var.environment_name}",
+      aws_ecr_repository.eligibility-screener-repository.arn,
+    ]
+  }
+  statement {
+    sid       = "WICLogin"
+    actions   = ["ecr:GetAuthorizationToken"]
+    resources = ["*"]
+  }
+}


### PR DESCRIPTION
## Ticket

https://wicmtdp.atlassian.net/browse/PRP-116

## Changes
* `infra/eligibility_screener` path added with the infrastructure for the eligibility screener repo

## Context for reviewers
> This ticket is for a migration of the terraform out of the project repo and into the Eligibility Screener repo. The end result should be that we should be able to manage AWS via terraform for the Eligibility Screener. 

> This ticket should not include any major refactoring of the terraform structure.  

## Testing
N/A
